### PR TITLE
Fbruggem/kfs 5/addressspace

### DIFF
--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -6,4 +6,5 @@ pub mod gdt;
 pub mod idt;
 pub mod interrupts;
 pub mod kernel_mutex;
+pub mod scheduler;
 pub mod vmm;

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -7,4 +7,5 @@ pub mod idt;
 pub mod interrupts;
 pub mod kernel_mutex;
 pub mod scheduler;
+pub mod syscall;
 pub mod vmm;

--- a/src/arch/x86/gdt.rs
+++ b/src/arch/x86/gdt.rs
@@ -59,6 +59,9 @@ pub const SEGMENT_SELECTOR_USER_CODE: usize = 3;
 pub const SEGMENT_SELECTOR_USER_DATA: usize = 4;
 pub const SEGMENT_SELECTOR_TSS: usize = 5;
 
+pub const SEGMENT_MODE_KERNEL: u32 = 0b00;
+pub const SEGMENT_MODE_USER: u32 = 0b11;
+
 pub fn init() {
     // SAFETY:
     // We know this is safe since this module is the only one that can access GDT.

--- a/src/arch/x86/gdt.rs
+++ b/src/arch/x86/gdt.rs
@@ -16,21 +16,15 @@ impl GdtEntry {
     }
 
     pub fn new(flags: u16, limit: u32, base: u32) -> Self {
-        let mut entry: u64 = 0;
+        let mut entry: u64;
 
-        // limit bits 0-15
-        entry |= u64::from(limit & 0xFFFF);
-        // base bits 0-15
-        entry |= u64::from(base & 0xFFFF) << 16;
-        // base bits 16-23
-        entry |= u64::from((base >> 16) & 0xFF) << 32;
-        // access byte (flags low byte)
-        entry |= u64::from(flags & 0xFF) << 40;
-        // limit bits 16-19 + flags high nibble
-        entry |= u64::from((limit >> 16) & 0xF) << 48;
-        entry |= u64::from((flags >> 8) & 0xF0) << 48;
-        // base bits 24-31
-        entry |= u64::from((base >> 24) & 0xFF) << 56;
+        entry = u64::from(limit) & 0x000F_0000;
+        entry |= (u64::from(flags) << 8) & 0x00F0_FF00;
+        entry |= (u64::from(base) >> 16) & 0x0000_00FF;
+        entry |= u64::from(base) & 0xFF00_0000;
+        entry <<= 32;
+        entry |= u64::from(base) << 16;
+        entry |= u64::from(limit) & 0x0000_FFFF;
 
         Self(entry)
     }

--- a/src/arch/x86/gdt.rs
+++ b/src/arch/x86/gdt.rs
@@ -76,8 +76,10 @@ pub fn init() {
     #[allow(static_mut_refs)]
     let stack_vaddr = unsafe { &STACK as *const _ as u32 };
     tss.esp0 = stack_vaddr + STACK_SIZE as u32 - 4;
-    tss.ss0 = (SEGMENT_SELECTOR_KERNEL_DATA << 3) as u32;
-    tss.iopb = 104;
+    tss.ss0 = (SEGMENT_SELECTOR_KERNEL_DATA << 3) as u32; // we don't need to set permission
+    // because it defaults to 00 (kernel)
+    // which we need.
+    tss.iopb = size_of::<TaskSwitchSegment>() as u16;
     gdt.entries[SEGMENT_SELECTOR_TSS] = GdtEntry::new(0x0089, (size_of::<TaskSwitchSegment>() - 1) as u32, tss_vaddr);
 
     // SAFETY:

--- a/src/arch/x86/gdt.rs
+++ b/src/arch/x86/gdt.rs
@@ -3,7 +3,6 @@ use core::arch::asm;
 use crate::{
     arch::x86::kernel_mutex::KernelMutex,
     boot::{STACK, STACK_SIZE},
-    serial_println,
 };
 
 #[derive(Copy, Clone)]
@@ -74,10 +73,10 @@ pub fn init() {
     gdt.entries[SEGMENT_SELECTOR_USER_DATA] = GdtEntry::new(0xC0F2, 0xFFFFF, 0x0);
 
     let mut tss = TSS.lock().expect("could not lock TSS on init");
-    let tss_vaddr = &*tss as *const TaskSwitchSegment as u32;
+    let tss_vaddr = &raw const *tss as u32;
 
     #[allow(static_mut_refs)]
-    let stack_vaddr = unsafe { &STACK as *const _ as u32 };
+    let stack_vaddr = unsafe { &raw const STACK as u32 };
     tss.esp0 = stack_vaddr + STACK_SIZE as u32 - 4;
     tss.ss0 = (SEGMENT_SELECTOR_KERNEL_DATA << 3) as u32; // we don't need to set permission
     // because it defaults to 00 (kernel)

--- a/src/arch/x86/gdt.rs
+++ b/src/arch/x86/gdt.rs
@@ -1,3 +1,11 @@
+use core::arch::asm;
+
+use crate::{
+    arch::x86::kernel_mutex::KernelMutex,
+    boot::{STACK, STACK_SIZE},
+    serial_println,
+};
+
 #[derive(Copy, Clone)]
 #[allow(unused)]
 struct GdtEntry(u64);
@@ -8,15 +16,21 @@ impl GdtEntry {
     }
 
     pub fn new(flags: u16, limit: u32, base: u32) -> Self {
-        let mut entry: u64;
+        let mut entry: u64 = 0;
 
-        entry = u64::from(limit) & 0x000F_0000;
-        entry |= (u64::from(flags) << 8) & 0x00F0_FF00;
-        entry |= (u64::from(base) >> 16) & 0x0000_00FF;
-        entry |= u64::from(base) & 0xFF00_0000;
-        entry <<= 32;
-        entry |= u64::from(base) << 16;
-        entry |= u64::from(limit) & 0x0000_FFFF;
+        // limit bits 0-15
+        entry |= u64::from(limit & 0xFFFF);
+        // base bits 0-15
+        entry |= u64::from(base & 0xFFFF) << 16;
+        // base bits 16-23
+        entry |= u64::from((base >> 16) & 0xFF) << 32;
+        // access byte (flags low byte)
+        entry |= u64::from(flags & 0xFF) << 40;
+        // limit bits 16-19 + flags high nibble
+        entry |= u64::from((limit >> 16) & 0xF) << 48;
+        entry |= u64::from((flags >> 8) & 0xF0) << 48;
+        // base bits 24-31
+        entry |= u64::from((base >> 24) & 0xFF) << 56;
 
         Self(entry)
     }
@@ -35,17 +49,21 @@ struct GlobalDescriptorTableRegister {
     base: u32,
 }
 
-const GDT_SIZE: usize = 7;
+const GDT_SIZE: usize = 6;
 static mut GDT: Gdt = Gdt {
     entries: [GdtEntry::disabled(); GDT_SIZE],
 };
 
 #[unsafe(no_mangle)]
-static mut GDTR: Gdtr = Gdtr { limit: 0x37, base: 0 };
+static mut GDTR: Gdtr = Gdtr {
+    limit: (GDT_SIZE * 8 - 1) as u16,
+    base: 0,
+};
 pub const SEGMENT_SELECTOR_KERNEL_CODE: usize = 1;
 pub const SEGMENT_SELECTOR_KERNEL_DATA: usize = 2;
 pub const SEGMENT_SELECTOR_USER_CODE: usize = 3;
 pub const SEGMENT_SELECTOR_USER_DATA: usize = 4;
+pub const SEGMENT_SELECTOR_TSS: usize = 5;
 
 pub fn init() {
     // SAFETY:
@@ -57,6 +75,16 @@ pub fn init() {
     gdt.entries[SEGMENT_SELECTOR_KERNEL_DATA] = GdtEntry::new(0xC092, 0xFFFFF, 0x0);
     gdt.entries[SEGMENT_SELECTOR_USER_CODE] = GdtEntry::new(0xC0FA, 0xFFFFF, 0x0);
     gdt.entries[SEGMENT_SELECTOR_USER_DATA] = GdtEntry::new(0xC0F2, 0xFFFFF, 0x0);
+
+    let mut tss = TSS.lock().expect("could not lock TSS on init");
+    let tss_vaddr = &*tss as *const TaskSwitchSegment as u32;
+
+    #[allow(static_mut_refs)]
+    let stack_vaddr = unsafe { &STACK as *const _ as u32 };
+    tss.esp0 = stack_vaddr + STACK_SIZE as u32 - 4;
+    tss.ss0 = (SEGMENT_SELECTOR_KERNEL_DATA << 3) as u32;
+    tss.iopb = 104;
+    gdt.entries[SEGMENT_SELECTOR_TSS] = GdtEntry::new(0x0089, (size_of::<TaskSwitchSegment>() - 1) as u32, tss_vaddr);
 
     // SAFETY:
     // We know this is safe since this module is the only one that can access GDTR.
@@ -75,6 +103,10 @@ pub fn init() {
     unsafe {
         // Reload segment registers "invisible" parts by setting them again.
         segment_registers_reload();
+    }
+
+    unsafe {
+        asm!("ltr ax", in("ax") SEGMENT_SELECTOR_TSS << 3);
     }
 }
 
@@ -103,3 +135,64 @@ unsafe extern "C" fn segment_registers_reload() {
 unsafe extern "C" fn gdt_set() {
     core::arch::naked_asm!("mov eax, offset GDTR", "lgdt [eax]", "mov eax, cr0", "or eax, 1", "mov cr0, eax", "ret",);
 }
+
+#[repr(C)]
+pub struct TaskSwitchSegment {
+    pub prev_tss: u32,
+    pub esp0: u32,
+    pub ss0: u32,
+    pub esp1: u32,
+    pub ss1: u32,
+    pub esp2: u32,
+    pub ss2: u32,
+    pub cr3: u32,
+    pub eip: u32,
+    pub eflags: u32,
+    pub eax: u32,
+    pub ecx: u32,
+    pub edx: u32,
+    pub ebx: u32,
+    pub esp: u32,
+    pub ebp: u32,
+    pub esi: u32,
+    pub edi: u32,
+    pub es: u32,
+    pub cs: u32,
+    pub ss: u32,
+    pub ds: u32,
+    pub fs: u32,
+    pub gs: u32,
+    pub ldt: u32,
+    pub trap: u16,
+    pub iopb: u16, // ← set to size_of::<Tss>() = 104
+}
+
+static TSS: KernelMutex<TaskSwitchSegment> = KernelMutex::new(TaskSwitchSegment {
+    prev_tss: 0,
+    esp0: 0,
+    ss0: (SEGMENT_SELECTOR_KERNEL_CODE << 3) as u32,
+    esp1: 0,
+    ss1: 0,
+    esp2: 0,
+    ss2: 0,
+    cr3: 0,
+    eip: 0,
+    eflags: 0,
+    eax: 0,
+    ecx: 0,
+    edx: 0,
+    ebx: 0,
+    esp: 0,
+    ebp: 0,
+    esi: 0,
+    edi: 0,
+    es: 0,
+    cs: 0,
+    ss: 0,
+    ds: 0,
+    fs: 0,
+    gs: 0,
+    ldt: 0,
+    trap: 0,
+    iopb: size_of::<TaskSwitchSegment>() as u16,
+});

--- a/src/arch/x86/gdt.rs
+++ b/src/arch/x86/gdt.rs
@@ -61,6 +61,7 @@ pub const SEGMENT_SELECTOR_TSS: usize = 5;
 pub const SEGMENT_MODE_KERNEL: u32 = 0b00;
 pub const SEGMENT_MODE_USER: u32 = 0b11;
 
+#[allow(clippy::missing_panics_doc)]
 pub fn init() {
     // SAFETY:
     // We know this is safe since this module is the only one that can access GDT.
@@ -72,11 +73,11 @@ pub fn init() {
     gdt.entries[SEGMENT_SELECTOR_USER_CODE] = GdtEntry::new(0xC0FA, 0xFFFFF, 0x0);
     gdt.entries[SEGMENT_SELECTOR_USER_DATA] = GdtEntry::new(0xC0F2, 0xFFFFF, 0x0);
 
+    #[allow(clippy::expect_used)]
     let mut tss = TSS.lock().expect("could not lock TSS on init");
     let tss_vaddr = &raw const *tss as u32;
 
-    #[allow(static_mut_refs)]
-    let stack_vaddr = unsafe { &raw const STACK as u32 };
+    let stack_vaddr = &raw const STACK as u32;
     tss.esp0 = stack_vaddr + STACK_SIZE as u32 - 4;
     tss.ss0 = (SEGMENT_SELECTOR_KERNEL_DATA << 3) as u32; // we don't need to set permission
     // because it defaults to 00 (kernel)
@@ -103,6 +104,8 @@ pub fn init() {
         segment_registers_reload();
     }
 
+    // SAFETY:
+    // This is safe because we setup TSS before
     unsafe {
         asm!("ltr ax", in("ax") SEGMENT_SELECTOR_TSS << 3);
     }

--- a/src/arch/x86/idt.rs
+++ b/src/arch/x86/idt.rs
@@ -4,9 +4,12 @@
 
 const KERNEL_CODE_OFFSET: usize = 0x8;
 use crate::{
-    arch::x86::interrupts::{
-        exception, irq,
-        pic::{self, send_eoi},
+    arch::x86::{
+        gdt,
+        interrupts::{
+            exception, irq,
+            pic::{self, send_eoi},
+        },
     },
     exception_stubs, irq_stubs, printk, printkln, serial_println,
 };
@@ -160,10 +163,11 @@ impl InterruptRegisters {
             esp: stack,
 
             // user data/stack segments - index 4 and 5 in GDT with RPL=3
-            ds: 0x23,
-            ss: 0x23,
+            ds: (gdt::SEGMENT_SELECTOR_USER_DATA << 3) as u32 | gdt::SEGMENT_MODE_USER,
+            ss: (gdt::SEGMENT_SELECTOR_USER_DATA << 3) as u32 | gdt::SEGMENT_MODE_USER,
+
             // user code segment - index 3 in GDT with RPL=3
-            csm: 0x1B,
+            csm: (gdt::SEGMENT_SELECTOR_USER_CODE << 3) as u32 | gdt::SEGMENT_MODE_USER,
 
             // IF set + reserved bit + IOPL=3 for user mode
             eflags: 0x3202,

--- a/src/arch/x86/idt.rs
+++ b/src/arch/x86/idt.rs
@@ -156,6 +156,7 @@ pub struct InterruptRegisters {
 }
 
 impl InterruptRegisters {
+    #[must_use]
     pub fn new(eip: u32, stack: u32) -> Self {
         Self {
             eip,

--- a/src/arch/x86/idt.rs
+++ b/src/arch/x86/idt.rs
@@ -152,6 +152,36 @@ pub struct InterruptRegisters {
     pub ss: u32,
 }
 
+impl InterruptRegisters {
+    pub fn new(eip: u32, stack: u32) -> Self {
+        Self {
+            eip,
+            useresp: stack,
+            esp: stack,
+
+            // user data/stack segments - index 4 and 5 in GDT with RPL=3
+            ds: 0x23,
+            ss: 0x23,
+            // user code segment - index 3 in GDT with RPL=3
+            csm: 0x1B,
+
+            // IF set + reserved bit + IOPL=3 for user mode
+            eflags: 0x3202,
+
+            cr2: 0,
+            edi: 0,
+            esi: 0,
+            ebp: 0,
+            ebx: 0,
+            edx: 0,
+            ecx: 0,
+            eax: 0,
+            intno: 0,
+            err_code: 0,
+        }
+    }
+}
+
 static mut IDT: Option<InterruptDescriptorTable> = None;
 
 pub fn init() {

--- a/src/arch/x86/idt.rs
+++ b/src/arch/x86/idt.rs
@@ -208,7 +208,7 @@ pub fn init() {
         InterruptDescriptor::new(
             crate::arch::x86::interrupts::exception::_stubs::syscall_stub as *const () as usize,
             KERNEL_CODE_OFFSET as u16,
-            Attributes::new(PresentBit::Present, PrivilegeLevel::KernelMode, GateType::InterruptGate32),
+            Attributes::new(PresentBit::Present, PrivilegeLevel::UserMode, GateType::InterruptGate32),
         ),
     );
 

--- a/src/arch/x86/interrupts/exception.rs
+++ b/src/arch/x86/interrupts/exception.rs
@@ -170,4 +170,5 @@ unsafe extern "C" fn exception_handler(regs: &InterruptRegisters) {
         0..32 => serial_println!("\nEXCEPTION {}: {}", regs.intno, EXCEPTION_MESSAGE[regs.intno as usize]),
         _ => panic!("{regs:?}"),
     }
+    panic!();
 }

--- a/src/arch/x86/interrupts/exception.rs
+++ b/src/arch/x86/interrupts/exception.rs
@@ -1,17 +1,9 @@
-use core::{intrinsics::copy_nonoverlapping, ptr::write_volatile};
 
 use crate::{
     arch::x86::{
         idt::InterruptRegisters,
-        scheduler::{Permissions, SCHEDULER, timer},
         syscall::{sys_exit, syscall},
-        vmm::{
-            PAGE_SIZE,
-            addressspace::Addressspace,
-            demand_pageing::page_fault,
-            process::{Process, VMA},
-            state::PAGE_ALLOCATOR,
-        },
+        vmm::demand_pageing::page_fault,
     },
     serial_println,
 };

--- a/src/arch/x86/interrupts/exception.rs
+++ b/src/arch/x86/interrupts/exception.rs
@@ -1,4 +1,18 @@
-use crate::{arch::x86::idt::InterruptRegisters, serial_println};
+use core::{intrinsics::copy_nonoverlapping, ptr::write_volatile};
+
+use crate::{
+    arch::x86::{
+        idt::InterruptRegisters,
+        scheduler::{Permissions, SCHEDULER, timer},
+        vmm::{
+            PAGE_SIZE,
+            addressspace::Addressspace,
+            process::{Process, VMA},
+            state::PAGE_ALLOCATOR,
+        },
+    },
+    serial_println,
+};
 
 macro_rules! no_err_stub {
     ($func: ident, $nb: expr) => {
@@ -163,12 +177,105 @@ const EXCEPTION_MESSAGE: &[&str] = &[
     "Reserved",
 ];
 
+pub extern "C" fn sys_exit(regs: &mut InterruptRegisters) {
+    serial_println!("exited while ebx was {}", regs.ebx);
+    let mut scheduler = SCHEDULER.lock().expect("timer | failed to lock SCHEDULER");
+
+    let pid = scheduler.current().expect("sys_exit | no process running").pid;
+
+    scheduler.exit(pid);
+
+    let next = scheduler.schedule().expect("no process to run");
+
+    next.state = crate::arch::x86::vmm::process::ProcessState::Running;
+    next.addressspace.load();
+    *regs = next.saved_registers;
+}
+fn sys_fork(regs: &mut InterruptRegisters) {
+    serial_println!("forked");
+    let mut scheduler = SCHEDULER.lock().expect("sys_fork | could not lock SCHEDULER");
+    let parent = scheduler.current().expect("sys_fork | no process running");
+    let mut child = Process::from_process(parent);
+    child.saved_registers.eax = 0;
+
+    drop(parent);
+    let child_pid = scheduler.spawn(child);
+
+    let parent = scheduler.current().expect("sys_fork | no process running");
+    parent.saved_registers.eax = child_pid as u32;
+    *regs = parent.saved_registers;
+}
+
+fn syscall(regs: &mut InterruptRegisters) {
+    match regs.eax {
+        60 => sys_exit(regs),
+        35 => timer(regs),
+        57 => sys_fork(regs),
+        _ => regs.eax = u32::MAX,
+    }
+}
+
 #[unsafe(no_mangle)]
-unsafe extern "C" fn exception_handler(regs: &InterruptRegisters) {
+unsafe extern "C" fn exception_handler(regs: &mut InterruptRegisters) {
     match regs.intno {
-        0x80 => serial_println!("SYSCALL\n"),
-        0..32 => serial_println!("\nEXCEPTION {}: {}", regs.intno, EXCEPTION_MESSAGE[regs.intno as usize]),
+        13 => sys_exit(regs),
+        14 => page_fault(regs),
+        0..32 => {
+            serial_println!("\nEXCEPTION {}: {}", regs.intno, EXCEPTION_MESSAGE[regs.intno as usize]);
+            sys_exit(regs);
+        }
+        0x80 => syscall(regs),
         _ => panic!("{regs:?}"),
     }
-    panic!();
 }
+
+fn page_fault(regs: &mut InterruptRegisters) {
+    serial_println!("page_fault: at addr {:x}", regs.cr2);
+    let mut scheduler = SCHEDULER.lock().expect("page_fault | could not lock SCHEDULER");
+
+    let addr = regs.cr2 as usize;
+    let addr = ((addr + PAGE_SIZE - 1) / PAGE_SIZE) * PAGE_SIZE;
+    let process = scheduler.current().expect("page_fault | no process running");
+
+    for vma in &process.vmas {
+        let access_allowed = vma.start <= addr && vma.start + vma.size > addr;
+        if access_allowed {
+            if let Ok(_) = alloc_page(addr, &mut process.addressspace, &vma) {
+                return;
+            }
+        }
+    }
+    drop(scheduler);
+    sys_exit(regs);
+}
+
+fn alloc_page(vaddr: usize, space: &mut Addressspace, vma: &VMA) -> Result<(), ()> {
+    let mut alloc = PAGE_ALLOCATOR.lock().expect("page_fault | could not lock PAGE_ALLOCATOR");
+    let paddr = match alloc.alloc(PAGE_SIZE) {
+        Some(paddr) => paddr,
+        None => {
+            return Err(());
+        }
+    };
+
+    let temp = 0xBFFF_F000 as *mut u8;
+
+    if let Some(offset) = vma.offset {
+        space.map(temp, paddr, Permissions::ReadWrite);
+        let diff = vaddr - vma.start;
+        unsafe {
+            copy_nonoverlapping((offset + diff) as *mut u8, temp, PAGE_SIZE);
+        }
+        space.unmap(temp);
+    }
+
+    space.map(vaddr as *mut u8, paddr, vma.permissions);
+    Ok(())
+}
+// pub struct VMA {
+//     start: usize,
+//     offset: Option<usize>,
+//     size: usize,
+//     permissions: Permissions,
+// }
+//

--- a/src/arch/x86/interrupts/exception.rs
+++ b/src/arch/x86/interrupts/exception.rs
@@ -1,4 +1,3 @@
-
 use crate::{
     arch::x86::{
         idt::InterruptRegisters,

--- a/src/arch/x86/interrupts/exception.rs
+++ b/src/arch/x86/interrupts/exception.rs
@@ -195,6 +195,7 @@ fn sys_fork(regs: &mut InterruptRegisters) {
     serial_println!("forked");
     let mut scheduler = SCHEDULER.lock().expect("sys_fork | could not lock SCHEDULER");
     let parent = scheduler.current().expect("sys_fork | no process running");
+    parent.saved_registers = *regs;
     let mut child = Process::from_process(parent);
     child.saved_registers.eax = 0;
 
@@ -203,7 +204,7 @@ fn sys_fork(regs: &mut InterruptRegisters) {
 
     let parent = scheduler.current().expect("sys_fork | no process running");
     parent.saved_registers.eax = child_pid as u32;
-    *regs = parent.saved_registers;
+    regs.eax = child_pid as u32;
 }
 
 fn syscall(regs: &mut InterruptRegisters) {

--- a/src/arch/x86/interrupts/exception.rs
+++ b/src/arch/x86/interrupts/exception.rs
@@ -4,9 +4,11 @@ use crate::{
     arch::x86::{
         idt::InterruptRegisters,
         scheduler::{Permissions, SCHEDULER, timer},
+        syscall::{sys_exit, syscall},
         vmm::{
             PAGE_SIZE,
             addressspace::Addressspace,
+            demand_pageing::page_fault,
             process::{Process, VMA},
             state::PAGE_ALLOCATOR,
         },
@@ -177,45 +179,6 @@ const EXCEPTION_MESSAGE: &[&str] = &[
     "Reserved",
 ];
 
-pub extern "C" fn sys_exit(regs: &mut InterruptRegisters) {
-    serial_println!("exited while ebx was {}", regs.ebx);
-    let mut scheduler = SCHEDULER.lock().expect("timer | failed to lock SCHEDULER");
-
-    let pid = scheduler.current().expect("sys_exit | no process running").pid;
-
-    scheduler.exit(pid);
-
-    let next = scheduler.schedule().expect("no process to run");
-
-    next.state = crate::arch::x86::vmm::process::ProcessState::Running;
-    next.addressspace.load();
-    *regs = next.saved_registers;
-}
-fn sys_fork(regs: &mut InterruptRegisters) {
-    serial_println!("forked");
-    let mut scheduler = SCHEDULER.lock().expect("sys_fork | could not lock SCHEDULER");
-    let parent = scheduler.current().expect("sys_fork | no process running");
-    parent.saved_registers = *regs;
-    let mut child = Process::from_process(parent);
-    child.saved_registers.eax = 0;
-
-    drop(parent);
-    let child_pid = scheduler.spawn(child);
-
-    let parent = scheduler.current().expect("sys_fork | no process running");
-    parent.saved_registers.eax = child_pid as u32;
-    regs.eax = child_pid as u32;
-}
-
-fn syscall(regs: &mut InterruptRegisters) {
-    match regs.eax {
-        60 => sys_exit(regs),
-        35 => timer(regs),
-        57 => sys_fork(regs),
-        _ => regs.eax = u32::MAX,
-    }
-}
-
 #[unsafe(no_mangle)]
 unsafe extern "C" fn exception_handler(regs: &mut InterruptRegisters) {
     match regs.intno {
@@ -229,54 +192,3 @@ unsafe extern "C" fn exception_handler(regs: &mut InterruptRegisters) {
         _ => panic!("{regs:?}"),
     }
 }
-
-fn page_fault(regs: &mut InterruptRegisters) {
-    serial_println!("page_fault: at addr {:x}", regs.cr2);
-    let mut scheduler = SCHEDULER.lock().expect("page_fault | could not lock SCHEDULER");
-
-    let addr = regs.cr2 as usize;
-    let addr = ((addr + PAGE_SIZE - 1) / PAGE_SIZE) * PAGE_SIZE;
-    let process = scheduler.current().expect("page_fault | no process running");
-
-    for vma in &process.vmas {
-        let access_allowed = vma.start <= addr && vma.start + vma.size > addr;
-        if access_allowed {
-            if let Ok(_) = alloc_page(addr, &mut process.addressspace, &vma) {
-                return;
-            }
-        }
-    }
-    drop(scheduler);
-    sys_exit(regs);
-}
-
-fn alloc_page(vaddr: usize, space: &mut Addressspace, vma: &VMA) -> Result<(), ()> {
-    let mut alloc = PAGE_ALLOCATOR.lock().expect("page_fault | could not lock PAGE_ALLOCATOR");
-    let paddr = match alloc.alloc(PAGE_SIZE) {
-        Some(paddr) => paddr,
-        None => {
-            return Err(());
-        }
-    };
-
-    let temp = 0xBFFF_F000 as *mut u8;
-
-    if let Some(offset) = vma.offset {
-        space.map(temp, paddr, Permissions::ReadWrite);
-        let diff = vaddr - vma.start;
-        unsafe {
-            copy_nonoverlapping((offset + diff) as *mut u8, temp, PAGE_SIZE);
-        }
-        space.unmap(temp);
-    }
-
-    space.map(vaddr as *mut u8, paddr, vma.permissions);
-    Ok(())
-}
-// pub struct VMA {
-//     start: usize,
-//     offset: Option<usize>,
-//     size: usize,
-//     permissions: Permissions,
-// }
-//

--- a/src/arch/x86/interrupts/irq.rs
+++ b/src/arch/x86/interrupts/irq.rs
@@ -92,13 +92,13 @@ extern "C" fn irq_common_stub(intno: u32, stack_ptr: u32) {
     )
 }
 
-static mut IRQ_ROUTINES: [Option<extern "C" fn(&InterruptRegisters)>; 16] = [None; 16];
+static mut IRQ_ROUTINES: [Option<extern "C" fn(&mut InterruptRegisters)>; 16] = [None; 16];
 
 /// Installs a handler for `irq`. Note that this does not unmask `irq`, it should be done
 /// explicitly by the caller.
 #[unsafe(no_mangle)]
 #[allow(static_mut_refs)]
-pub fn install_handler(irq: u32, handler: extern "C" fn(&InterruptRegisters)) {
+pub fn install_handler(irq: u32, handler: extern "C" fn(&mut InterruptRegisters)) {
     let _lock = IRQLock::lock(irq as u8);
     // SAFETY:
     // We are mutating IRQ_ROUTINES, which we know is valid for the entire lifetime of the program, and
@@ -118,7 +118,7 @@ unsafe fn uninstall_handler(irq: u32) {
 
 #[unsafe(no_mangle)]
 #[allow(static_mut_refs)]
-unsafe extern "C" fn irq_handler(regs: &InterruptRegisters) {
+unsafe extern "C" fn irq_handler(regs: &mut InterruptRegisters) {
     #[allow(clippy::cast_possible_wrap)]
     let irq_index = if regs.intno as isize - 32 < 0 {
         return;

--- a/src/arch/x86/scheduler.rs
+++ b/src/arch/x86/scheduler.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used)]
+#![allow(clippy::unwrap_used)]
 use core::arch::naked_asm;
 
 use alloc::vec::Vec;
@@ -13,6 +15,7 @@ use crate::{
 };
 
 #[unsafe(naked)]
+#[allow(unused)]
 extern "C" fn program_exit() {
     naked_asm!("aaa:", "mov eax, 60", "int 0x80", "jmp aaa");
 }
@@ -100,10 +103,13 @@ impl Binary {
     }
 }
 
+#[allow(unused)]
 static ONE: u32 = 1;
 
+#[allow(unused)]
 static TWO: u32 = 2;
 
+#[allow(clippy::missing_panics_doc)]
 pub fn init() {
     let mut init = Binary::new(0x1000, 0x2000);
     init.segments.push(Segment {
@@ -128,6 +134,7 @@ pub fn init() {
 
 pub static SCHEDULER: KernelMutex<Scheduler> = KernelMutex::new(Scheduler::new());
 
+#[allow(clippy::missing_panics_doc)]
 pub extern "C" fn timer(regs: &mut InterruptRegisters) {
     serial_println!("timer");
     serial_println!("{:x}", regs.eax);

--- a/src/arch/x86/scheduler.rs
+++ b/src/arch/x86/scheduler.rs
@@ -1,4 +1,4 @@
-use core::{arch::naked_asm, ptr::write_volatile};
+use core::arch::naked_asm;
 
 use alloc::vec::Vec;
 
@@ -7,10 +7,7 @@ use crate::{
         idt::InterruptRegisters,
         interrupts::irq,
         kernel_mutex::KernelMutex,
-        vmm::{
-            addressspace::Addressspace,
-            process::{Process, Scheduler},
-        },
+        vmm::process::{Process, Scheduler},
     },
     serial_println,
 };
@@ -93,6 +90,7 @@ pub struct Binary {
 }
 
 impl Binary {
+    #[must_use]
     pub fn new(entry: usize, stack: usize) -> Self {
         Self {
             segments: Vec::new(),
@@ -102,20 +100,20 @@ impl Binary {
     }
 }
 
-static one: u32 = 1;
+static ONE: u32 = 1;
 
-static two: u32 = 2;
+static TWO: u32 = 2;
 
 pub fn init() {
     let mut init = Binary::new(0x1000, 0x2000);
     init.segments.push(Segment {
-        offset: Some(program_write_in_memory as usize),
+        offset: Some(program_write_in_memory as *const () as usize),
         vaddr: 0x1000,
         size: 0x1000,
         permissions: Permissions::Read,
     });
     init.segments.push(Segment {
-        offset: Some(&one as *const _ as usize),
+        offset: Some(&raw const ONE as usize),
         vaddr: 0x2000,
         size: 0x1000,
         permissions: Permissions::ReadWrite,

--- a/src/arch/x86/scheduler.rs
+++ b/src/arch/x86/scheduler.rs
@@ -1,0 +1,118 @@
+use core::{arch::naked_asm, ptr::write_volatile};
+
+use alloc::vec::Vec;
+
+use crate::{
+    arch::x86::{
+        idt::InterruptRegisters,
+        interrupts::irq,
+        kernel_mutex::KernelMutex,
+        vmm::{
+            addressspace::Addressspace,
+            process::{Process, Scheduler},
+        },
+    },
+    serial_println,
+};
+
+#[unsafe(naked)]
+extern "C" fn program_exit() {
+    naked_asm!("aaa:", "mov eax, 60", "int 0x80", "jmp aaa");
+}
+#[unsafe(naked)]
+extern "C" fn program() {
+    naked_asm!(
+        // write 0x42 to address 0x2000
+        "mov dword ptr [0x2000], 0x42",
+        // fork
+        "mov eax, 57",
+        "int 0x80",
+        // eax is now 0 in child, child_pid in parent
+
+        // both parent and child now read from 0x2000
+        // they should each see 0x42 because the page was copied
+        "mov ebx, [0x2000]",
+        // exit with the value we read as the exit code
+        "mov eax, 60",
+        "int 0x80",
+    );
+}
+// #[unsafe(naked)]
+// extern "C" fn program() {
+//     naked_asm!("aaaa:", "mov eax, 57", "int 0x80", "mov ebx, eax", "mov eax, 60", "int 0x80",
+// "jmp aaaa"); }
+
+#[derive(Clone, Copy)]
+#[repr(u8)]
+pub enum Permissions {
+    Read = 0,
+    ReadWrite = 1,
+}
+
+pub struct Segment {
+    pub offset: Option<usize>,
+    pub vaddr: usize,
+    pub size: usize,
+    pub permissions: Permissions,
+}
+
+pub struct Binary {
+    pub segments: Vec<Segment>,
+    pub entry: usize,
+    pub stack: usize,
+}
+
+impl Binary {
+    pub fn new(entry: usize, stack: usize) -> Self {
+        Self {
+            segments: Vec::new(),
+            entry,
+            stack,
+        }
+    }
+}
+
+static one: u32 = 1;
+
+static two: u32 = 2;
+
+pub fn init() {
+    let mut init = Binary::new(0x1000, 0x2000);
+    init.segments.push(Segment {
+        offset: Some(program as usize),
+        vaddr: 0x1000,
+        size: 0x1000,
+        permissions: Permissions::Read,
+    });
+    init.segments.push(Segment {
+        offset: Some(&one as *const _ as usize),
+        vaddr: 0x2000,
+        size: 0x1000,
+        permissions: Permissions::ReadWrite,
+    });
+
+    let p = Process::new(&init);
+    SCHEDULER.lock().unwrap().spawn(p);
+
+    irq::install_handler(0, timer);
+    irq::clear_mask(0);
+}
+
+pub static SCHEDULER: KernelMutex<Scheduler> = KernelMutex::new(Scheduler::new());
+
+pub extern "C" fn timer(regs: &mut InterruptRegisters) {
+    serial_println!("timer");
+    serial_println!("{:x}", regs.eax);
+    let mut scheduler = SCHEDULER.lock().expect("timer | failed to lock SCHEDULER");
+    // first save the registers if there was a running process
+    if let Some(p) = scheduler.current() {
+        p.saved_registers = *regs;
+    }
+
+    // find the next process
+    let next = scheduler.schedule().expect("no process to run");
+
+    next.state = crate::arch::x86::vmm::process::ProcessState::Running;
+    next.addressspace.load();
+    *regs = next.saved_registers;
+}

--- a/src/arch/x86/scheduler.rs
+++ b/src/arch/x86/scheduler.rs
@@ -19,24 +19,54 @@ use crate::{
 extern "C" fn program_exit() {
     naked_asm!("aaa:", "mov eax, 60", "int 0x80", "jmp aaa");
 }
+
 #[unsafe(naked)]
 extern "C" fn program() {
     naked_asm!(
-        // write 0x42 to address 0x2000
+        // both processes start by writing the same initial value
         "mov dword ptr [0x2000], 0x42",
         // fork
         "mov eax, 57",
         "int 0x80",
-        // eax is now 0 in child, child_pid in parent
+        // after this: eax = 0 in child, eax = child_pid in parent
 
-        // both parent and child now read from 0x2000
-        // they should each see 0x42 because the page was copied
+        // branch on eax
+        "test eax, eax",
+        "jz child",
+        // ----- parent path -----
+        // overwrite with 0xAAAA - this should NOT affect the child
+        "mov dword ptr [0x2000], 0xAAAA",
+        "jmp done",
+        "child:",
+        // ----- child path -----
+        // overwrite with 0xBBBB - this should NOT affect the parent
+        "mov dword ptr [0x2000], 0xBBBB",
+        "done:",
+        // both processes read their own [0x2000] into ebx and exit
         "mov ebx, [0x2000]",
-        // exit with the value we read as the exit code
         "mov eax, 60",
         "int 0x80",
     );
 }
+
+// #[unsafe(naked)]
+// extern "C" fn program() {
+//     naked_asm!(
+//         // write 0x42 to address 0x2000
+//         "mov dword ptr [0x2000], 0x42",
+//         // fork
+//         "mov eax, 57",
+//         "int 0x80",
+//         // eax is now 0 in child, child_pid in parent
+//
+//         // both parent and child now read from 0x2000
+//         // they should each see 0x42 because the page was copied
+//         "mov ebx, [0x2000]",
+//         // exit with the value we read as the exit code
+//         "mov eax, 60",
+//         "int 0x80",
+//     );
+// }
 // #[unsafe(naked)]
 // extern "C" fn program() {
 //     naked_asm!("aaaa:", "mov eax, 57", "int 0x80", "mov ebx, eax", "mov eax, 60", "int 0x80",
@@ -91,7 +121,7 @@ pub fn init() {
         permissions: Permissions::ReadWrite,
     });
 
-    let p = Process::new(&init);
+    let p = Process::new(&init, super::vmm::process::Parent::Root);
     SCHEDULER.lock().unwrap().spawn(p);
 
     irq::install_handler(0, timer);

--- a/src/arch/x86/scheduler.rs
+++ b/src/arch/x86/scheduler.rs
@@ -21,7 +21,7 @@ extern "C" fn program_exit() {
 }
 
 #[unsafe(naked)]
-extern "C" fn program() {
+extern "C" fn program_write_in_memory() {
     naked_asm!(
         // both processes start by writing the same initial value
         "mov dword ptr [0x2000], 0x42",
@@ -109,7 +109,7 @@ static two: u32 = 2;
 pub fn init() {
     let mut init = Binary::new(0x1000, 0x2000);
     init.segments.push(Segment {
-        offset: Some(program as usize),
+        offset: Some(program_write_in_memory as usize),
         vaddr: 0x1000,
         size: 0x1000,
         permissions: Permissions::Read,

--- a/src/arch/x86/syscall.rs
+++ b/src/arch/x86/syscall.rs
@@ -1,0 +1,48 @@
+use crate::{
+    arch::x86::{
+        idt::InterruptRegisters,
+        scheduler::{SCHEDULER, timer},
+        vmm::process::Process,
+    },
+    serial_println,
+};
+
+pub extern "C" fn sys_exit(regs: &mut InterruptRegisters) {
+    serial_println!("exited while ebx was {}", regs.ebx);
+    let mut scheduler = SCHEDULER.lock().expect("timer | failed to lock SCHEDULER");
+
+    let pid = scheduler.current().expect("sys_exit | no process running").pid;
+
+    scheduler.exit(pid);
+
+    let next = scheduler.schedule().expect("no process to run");
+
+    next.state = crate::arch::x86::vmm::process::ProcessState::Running;
+    next.addressspace.load();
+    *regs = next.saved_registers;
+}
+
+pub fn sys_fork(regs: &mut InterruptRegisters) {
+    serial_println!("forked");
+    let mut scheduler = SCHEDULER.lock().expect("sys_fork | could not lock SCHEDULER");
+    let parent = scheduler.current().expect("sys_fork | no process running");
+    parent.saved_registers = *regs;
+    let mut child = Process::from_process(parent);
+    child.saved_registers.eax = 0;
+
+    drop(parent);
+    let child_pid = scheduler.spawn(child);
+
+    let parent = scheduler.current().expect("sys_fork | no process running");
+    parent.saved_registers.eax = child_pid as u32;
+    regs.eax = child_pid as u32;
+}
+
+pub fn syscall(regs: &mut InterruptRegisters) {
+    match regs.eax {
+        35 => timer(regs),
+        57 => sys_fork(regs),
+        60 => sys_exit(regs),
+        _ => regs.eax = u32::MAX,
+    }
+}

--- a/src/arch/x86/syscall.rs
+++ b/src/arch/x86/syscall.rs
@@ -30,7 +30,7 @@ pub fn sys_fork(regs: &mut InterruptRegisters) {
     let mut child = Process::from_process(parent);
     child.saved_registers.eax = 0;
 
-    drop(parent);
+    let _ = parent; // drop
     let child_pid = scheduler.spawn(child);
 
     let parent = scheduler.current().expect("sys_fork | no process running");

--- a/src/arch/x86/syscall.rs
+++ b/src/arch/x86/syscall.rs
@@ -38,6 +38,12 @@ pub fn sys_fork(regs: &mut InterruptRegisters) {
     regs.eax = child_pid as u32;
 }
 
+pub fn sys_getpid(regs: &mut InterruptRegisters) {
+    let mut scheduler = SCHEDULER.lock().expect("sys_fork | could not lock SCHEDULER");
+    let cur = scheduler.current().expect("sys_fork | no process running");
+    regs.eax = cur.pid as u32;
+}
+
 pub fn syscall(regs: &mut InterruptRegisters) {
     match regs.eax {
         35 => timer(regs),

--- a/src/arch/x86/syscall.rs
+++ b/src/arch/x86/syscall.rs
@@ -34,6 +34,7 @@ pub fn sys_fork(regs: &mut InterruptRegisters) {
     let child_pid = scheduler.spawn(child);
 
     let parent = scheduler.current().expect("sys_fork | no process running");
+    parent.children.push(child_pid);
     parent.saved_registers.eax = child_pid as u32;
     regs.eax = child_pid as u32;
 }

--- a/src/arch/x86/syscall.rs
+++ b/src/arch/x86/syscall.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used)]
+#![allow(clippy::missing_panics_doc)]
 use crate::{
     arch::x86::{
         idt::InterruptRegisters,

--- a/src/arch/x86/vmm.rs
+++ b/src/arch/x86/vmm.rs
@@ -4,11 +4,11 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::borrow_as_ptr)]
 pub mod addressspace;
-mod allocators;
+pub mod allocators;
 pub mod demand_pageing;
-mod init;
-mod page;
-mod page_allocator;
+pub mod init;
+pub mod page;
+pub mod page_allocator;
 pub mod process;
 pub mod state;
 

--- a/src/arch/x86/vmm.rs
+++ b/src/arch/x86/vmm.rs
@@ -8,7 +8,7 @@ mod allocators;
 mod init;
 mod page;
 mod page_allocator;
-mod process;
+pub mod process;
 pub mod state;
 
 pub use init::init;

--- a/src/arch/x86/vmm.rs
+++ b/src/arch/x86/vmm.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::borrow_as_ptr)]
 pub mod addressspace;
 mod allocators;
+pub mod demand_pageing;
 mod init;
 mod page;
 mod page_allocator;

--- a/src/arch/x86/vmm.rs
+++ b/src/arch/x86/vmm.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::expect_used)]
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::borrow_as_ptr)]
+pub mod addressspace;
 mod allocators;
 mod init;
 mod page;

--- a/src/arch/x86/vmm.rs
+++ b/src/arch/x86/vmm.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::expect_used)]
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::borrow_as_ptr)]
-pub mod allocators;
+mod allocators;
 mod init;
 mod page;
 mod page_allocator;

--- a/src/arch/x86/vmm.rs
+++ b/src/arch/x86/vmm.rs
@@ -8,7 +8,8 @@ mod allocators;
 mod init;
 mod page;
 mod page_allocator;
-mod state;
+mod process;
+pub mod state;
 
 pub use init::init;
 pub use page::PAGE_SIZE;

--- a/src/arch/x86/vmm/addressspace.rs
+++ b/src/arch/x86/vmm/addressspace.rs
@@ -1,11 +1,14 @@
 use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
 
 use crate::{
-    arch::x86::vmm::{
-        PAGE_SIZE,
-        init::load_page_directory,
-        page::{PAGE_DIRECTORY_SIZE, PAGE_TABLE_SIZE, PageDirectory, PageDirectoryEntry, PageTable, PageTableEntry},
-        state::{PAGE_ALLOCATOR, PAGE_DIRECTORY_KERNEL},
+    arch::x86::{
+        scheduler::Permissions,
+        vmm::{
+            PAGE_SIZE,
+            init::load_page_directory,
+            page::{PAGE_DIRECTORY_SIZE, PAGE_TABLE_SIZE, PageDirectory, PageDirectoryEntry, PageTable, PageTableEntry},
+            state::{PAGE_ALLOCATOR, PAGE_DIRECTORY_KERNEL},
+        },
     },
     boot::KERNEL_BASE,
 };
@@ -30,7 +33,7 @@ impl Addressspace {
         }
     }
 
-    pub fn map(&mut self, vaddr: *const u8, paddr: *const u8, permissions: u8) {
+    pub fn map(&mut self, vaddr: *const u8, paddr: *const u8, permissions: Permissions) {
         let vaddr = vaddr as usize;
         let paddr = paddr as usize;
 
@@ -54,7 +57,7 @@ impl Addressspace {
         let mut pte = PageTableEntry::empty();
         pte.set_address((paddr >> 12) as u32);
         pte.set_user_supervisor(1);
-        pte.set_read_write(permissions);
+        pte.set_read_write(permissions as u8);
         pte.set_present(1);
         pt[pt_idx] = pte;
 
@@ -62,7 +65,66 @@ impl Addressspace {
             core::arch::asm!("invlpg [{}]", in(reg) vaddr, options(nostack, preserves_flags));
         }
     }
+    pub fn fork(&mut self) -> Self {
+        let mut child = Addressspace::new();
+        const SCRATCH: usize = 0xBFFF_F000;
 
+        for (&pde_idx, parent_pt) in &self.page_tables {
+            if pde_idx >= 768 {
+                continue;
+            }
+
+            for pt_idx in 0..PAGE_TABLE_SIZE {
+                let parent_pte = parent_pt[pt_idx];
+                if parent_pte.present() == 0 {
+                    continue;
+                }
+
+                let vaddr = ((pde_idx as usize) << 22) | (pt_idx << 12);
+                let parent_paddr = (parent_pte.address() as usize) << 12;
+
+                // allocate a fresh physical page for the child
+                let new_paddr = PAGE_ALLOCATOR
+                    .lock()
+                    .expect("fork | couldn't lock PAGE_ALLOCATOR")
+                    .alloc(PAGE_SIZE)
+                    .expect("fork | out of memory");
+
+                // temporarily map the new physical page into the current
+                // address space at SCRATCH so we can write into it
+                // self is the parent - we need to map in the currently
+                // active address space which is the parent's
+                unsafe {
+                    // map SCRATCH -> new_paddr in the currently active page directory
+                    // we cast away const here because we need to mutate self temporarily
+                    let parent_mut = &mut *(self as *const Self as *mut Self);
+                    parent_mut.map(SCRATCH as *const u8, new_paddr, Permissions::ReadWrite);
+                }
+
+                // copy the parent page content into the scratch window
+                let src = vaddr as *const u8;
+                let dst = SCRATCH as *mut u8;
+                unsafe {
+                    core::ptr::copy_nonoverlapping(src, dst, PAGE_SIZE);
+                }
+
+                // unmap the scratch window
+                unsafe {
+                    let parent_mut = &mut *(self as *const Self as *mut Self);
+                    parent_mut.unmap(SCRATCH as *const u8);
+                }
+
+                // map the new page into the child at the same virtual address
+                let perm = match parent_pte.read_write() {
+                    0 => Permissions::Read,
+                    _ => Permissions::ReadWrite,
+                };
+                child.map(vaddr as *const u8, new_paddr, perm);
+            }
+        }
+
+        child
+    }
     pub fn unmap(&mut self, vaddr: *const u8) {
         let vaddr = vaddr as usize;
         let pde_idx = (vaddr >> 22) as u16;

--- a/src/arch/x86/vmm/addressspace.rs
+++ b/src/arch/x86/vmm/addressspace.rs
@@ -27,6 +27,7 @@ impl Addressspace {
     pub fn new() -> Self {
         let mut pd = Box::new(PageDirectory::empty());
 
+        #[allow(clippy::missing_panics_doc)]
         let page_directory_kernel = PAGE_DIRECTORY_KERNEL.lock().expect("addressspace::new() | couldn't lock PAGE_ALLOCATOR");
 
         for i in 0..PAGE_DIRECTORY_SIZE {
@@ -38,6 +39,8 @@ impl Addressspace {
         }
     }
 
+    /// # Panics
+    /// This panics if the vaddr is ove `KERNEL_BASE`
     pub fn map(&mut self, vaddr: *const u8, paddr: *const u8, permissions: Permissions) {
         let vaddr = vaddr as usize;
         let paddr = paddr as usize;
@@ -66,6 +69,8 @@ impl Addressspace {
         pte.set_present(1);
         pt[pt_idx] = pte;
 
+        // SAFETY:
+        // This is safe because we just put this vaddr into the page table.
         unsafe {
             core::arch::asm!("invlpg [{}]", in(reg) vaddr, options(nostack, preserves_flags));
         }
@@ -88,12 +93,17 @@ impl Addressspace {
                 let vaddr = ((pde_idx as usize) << 22) | (pt_idx << 12);
                 let _parent_paddr = (parent_pte.address() as usize) << 12;
 
+                #[allow(clippy::missing_panics_doc)]
                 let new_paddr = PAGE_ALLOCATOR
                     .lock()
                     .expect("fork | couldn't lock PAGE_ALLOCATOR")
                     .alloc(PAGE_SIZE)
                     .expect("fork | out of memory");
 
+                // SAFETY:
+                // We use this so that we can go around the borrow checker because we loop over the
+                // page and only map the pages to `SCRATCH`, to copy over the memory from the
+                // parent to the child.
                 unsafe {
                     let parent_mut = &mut *(self as *const Self as *mut Self);
                     parent_mut.map(SCRATCH as *const u8, new_paddr, Permissions::ReadWrite);
@@ -101,10 +111,19 @@ impl Addressspace {
 
                 let src = vaddr as *const u8;
                 let dst = SCRATCH as *mut u8;
+
+                // TODO:
+                // make it so that a mmap call to the SCRATCH address fails.
+                // SAFETY:
+                // This is save because we just mapped dst and src is mapped throug a previous map
                 unsafe {
                     core::ptr::copy_nonoverlapping(src, dst, PAGE_SIZE);
                 }
 
+                // SAFETY:
+                // We use this so that we can go around the borrow checker because we loop over the
+                // page and only umap the pages to `SCRATCH`,  after we copied the memory from the
+                // parent
                 unsafe {
                     let parent_mut = &mut *(self as *const Self as *mut Self);
                     parent_mut.unmap(SCRATCH as *const u8);
@@ -145,13 +164,17 @@ impl Addressspace {
     }
 
     fn cr3(&self) -> *const PageDirectory {
-        unsafe { (&*self.page_directory as *const _ as usize - KERNEL_BASE) as *const PageDirectory  }
+        (&*self.page_directory as *const _ as usize - KERNEL_BASE) as *const PageDirectory
     }
 
+    #[allow(clippy::missing_panics_doc)]
     pub fn load(&self) {
         let addr = self.cr3();
         assert!(addr as usize % PAGE_SIZE == 0);
 
+        // SAFETY:
+        // This is safe because we make sure on new() that this is a page aligned address that is
+        // filled. And we also check it again one line up.
         unsafe {
             core::arch::asm!("mov cr3, {}", in(reg) addr, options(nostack, preserves_flags));
         }

--- a/src/arch/x86/vmm/addressspace.rs
+++ b/src/arch/x86/vmm/addressspace.rs
@@ -1,0 +1,98 @@
+use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
+
+use crate::{
+    arch::x86::vmm::{
+        PAGE_SIZE,
+        init::load_page_directory,
+        page::{PAGE_DIRECTORY_SIZE, PAGE_TABLE_SIZE, PageDirectory, PageDirectoryEntry, PageTable, PageTableEntry},
+        state::{PAGE_ALLOCATOR, PAGE_DIRECTORY_KERNEL},
+    },
+    boot::KERNEL_BASE,
+};
+
+pub struct Addressspace {
+    page_directory: Box<PageDirectory>,
+    page_tables: BTreeMap<u16, Box<PageTable>>,
+}
+
+impl Addressspace {
+    pub fn new() -> Self {
+        let mut pd = Box::new(PageDirectory::empty());
+
+        let page_directory_kernel = PAGE_DIRECTORY_KERNEL.lock().expect("addressspace::new() | couldn't lock PAGE_ALLOCATOR");
+
+        for i in 0..PAGE_DIRECTORY_SIZE {
+            pd[i] = page_directory_kernel[i];
+        }
+        Self {
+            page_directory: pd,
+            page_tables: BTreeMap::new(),
+        }
+    }
+
+    pub fn map(&mut self, vaddr: *const u8, paddr: *const u8, permissions: u8) {
+        let vaddr = vaddr as usize;
+        let paddr = paddr as usize;
+
+        let pde_idx = vaddr >> 22;
+        let pt_idx = (vaddr >> 12) & 0x3FF;
+        assert!(pde_idx < 768, "user mapping in kernel half");
+
+        let pt_paddr = {
+            let (_pt, pt_paddr) = self.get_or_create(pde_idx as u16);
+            pt_paddr
+        };
+
+        let mut pde = PageDirectoryEntry::empty();
+        pde.set_address((pt_paddr >> 12) as u32);
+        pde.set_user_supervisor(1);
+        pde.set_read_write(1);
+        pde.set_present(1);
+        self.page_directory[pde_idx] = pde;
+
+        let pt = self.page_tables.get_mut(&(pde_idx as u16)).expect("just created");
+        let mut pte = PageTableEntry::empty();
+        pte.set_address((paddr >> 12) as u32);
+        pte.set_user_supervisor(1);
+        pte.set_read_write(permissions);
+        pte.set_present(1);
+        pt[pt_idx] = pte;
+    }
+
+    pub fn unmap(&mut self, vaddr: *const u8) {
+        let vaddr = vaddr as usize;
+        let pde_idx = (vaddr >> 22) as u16;
+
+        let Some(pt) = self.page_tables.get_mut(&pde_idx) else { return };
+        let pt_idx = (vaddr >> 12) & 0x3FF;
+        pt[pt_idx] = PageTableEntry::empty();
+
+        if pt.iter().all(|pte| pte.present() == 0) {
+            self.page_directory[pde_idx as usize] = PageDirectoryEntry::empty();
+            self.page_tables.remove(&pde_idx);
+        }
+    }
+
+    pub fn get_or_create(&mut self, pde_idx: u16) -> (&mut PageTable, usize) {
+        let pt = self.page_tables.entry(pde_idx).or_insert_with(|| Box::new(PageTable::empty()));
+        let paddr = (&raw const **pt as usize) - KERNEL_BASE;
+        (pt, paddr)
+    }
+
+    pub fn remove(&mut self, pde_idx: u16) -> Option<Box<PageTable>> {
+        self.page_tables.remove(&pde_idx)
+    }
+
+    fn cr3(&self) -> *const PageDirectory {
+        unsafe { ((&*self.page_directory as *const _ as usize - KERNEL_BASE) as *const PageDirectory) }
+    }
+
+    pub fn load(&self) {
+        let addr = self.cr3();
+        assert!(addr as usize % PAGE_SIZE == 0);
+
+        unsafe {
+            core::arch::asm!("mov cr3, {}", in(reg) addr, options(nostack, preserves_flags));
+        }
+    }
+}

--- a/src/arch/x86/vmm/addressspace.rs
+++ b/src/arch/x86/vmm/addressspace.rs
@@ -83,38 +83,28 @@ impl Addressspace {
                 let vaddr = ((pde_idx as usize) << 22) | (pt_idx << 12);
                 let parent_paddr = (parent_pte.address() as usize) << 12;
 
-                // allocate a fresh physical page for the child
                 let new_paddr = PAGE_ALLOCATOR
                     .lock()
                     .expect("fork | couldn't lock PAGE_ALLOCATOR")
                     .alloc(PAGE_SIZE)
                     .expect("fork | out of memory");
 
-                // temporarily map the new physical page into the current
-                // address space at SCRATCH so we can write into it
-                // self is the parent - we need to map in the currently
-                // active address space which is the parent's
                 unsafe {
-                    // map SCRATCH -> new_paddr in the currently active page directory
-                    // we cast away const here because we need to mutate self temporarily
                     let parent_mut = &mut *(self as *const Self as *mut Self);
                     parent_mut.map(SCRATCH as *const u8, new_paddr, Permissions::ReadWrite);
                 }
 
-                // copy the parent page content into the scratch window
                 let src = vaddr as *const u8;
                 let dst = SCRATCH as *mut u8;
                 unsafe {
                     core::ptr::copy_nonoverlapping(src, dst, PAGE_SIZE);
                 }
 
-                // unmap the scratch window
                 unsafe {
                     let parent_mut = &mut *(self as *const Self as *mut Self);
                     parent_mut.unmap(SCRATCH as *const u8);
                 }
 
-                // map the new page into the child at the same virtual address
                 let perm = match parent_pte.read_write() {
                     0 => Permissions::Read,
                     _ => Permissions::ReadWrite,

--- a/src/arch/x86/vmm/addressspace.rs
+++ b/src/arch/x86/vmm/addressspace.rs
@@ -57,6 +57,10 @@ impl Addressspace {
         pte.set_read_write(permissions);
         pte.set_present(1);
         pt[pt_idx] = pte;
+
+        unsafe {
+            core::arch::asm!("invlpg [{}]", in(reg) vaddr, options(nostack, preserves_flags));
+        }
     }
 
     pub fn unmap(&mut self, vaddr: *const u8) {

--- a/src/arch/x86/vmm/addressspace.rs
+++ b/src/arch/x86/vmm/addressspace.rs
@@ -1,11 +1,10 @@
-use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
+use alloc::{boxed::Box, collections::BTreeMap};
 
 use crate::{
     arch::x86::{
         scheduler::Permissions,
         vmm::{
             PAGE_SIZE,
-            init::load_page_directory,
             page::{PAGE_DIRECTORY_SIZE, PAGE_TABLE_SIZE, PageDirectory, PageDirectoryEntry, PageTable, PageTableEntry},
             state::{PAGE_ALLOCATOR, PAGE_DIRECTORY_KERNEL},
         },
@@ -16,6 +15,12 @@ use crate::{
 pub struct Addressspace {
     page_directory: Box<PageDirectory>,
     page_tables: BTreeMap<u16, Box<PageTable>>,
+}
+
+impl Default for Addressspace {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Addressspace {
@@ -81,7 +86,7 @@ impl Addressspace {
                 }
 
                 let vaddr = ((pde_idx as usize) << 22) | (pt_idx << 12);
-                let parent_paddr = (parent_pte.address() as usize) << 12;
+                let _parent_paddr = (parent_pte.address() as usize) << 12;
 
                 let new_paddr = PAGE_ALLOCATOR
                     .lock()
@@ -140,7 +145,7 @@ impl Addressspace {
     }
 
     fn cr3(&self) -> *const PageDirectory {
-        unsafe { ((&*self.page_directory as *const _ as usize - KERNEL_BASE) as *const PageDirectory) }
+        unsafe { (&*self.page_directory as *const _ as usize - KERNEL_BASE) as *const PageDirectory  }
     }
 
     pub fn load(&self) {

--- a/src/arch/x86/vmm/allocators/backend/buddy.rs
+++ b/src/arch/x86/vmm/allocators/backend/buddy.rs
@@ -6,7 +6,7 @@ use crate::{
     expect_opt,
 };
 
-pub const BUDDY_ALLOCATOR_SIZE: usize = 1 << 29;
+pub const BUDDY_ALLOCATOR_SIZE: usize = 1 << 28;
 
 pub enum BuddyAllocationError {
     NotEnoughMemory,

--- a/src/arch/x86/vmm/allocators/backend/slab.rs
+++ b/src/arch/x86/vmm/allocators/backend/slab.rs
@@ -57,6 +57,7 @@ pub trait SlabOps: IntrusiveLink + Sized {
     fn max_objects(&self) -> usize;
 
     /// Returns the size of one object managed by this `Slab` (`self.object_size`).
+    #[allow(unused)]
     fn object_size(&self) -> usize;
 
     /// Returns the amount of objects already allocated in this `Slab`.
@@ -584,6 +585,7 @@ impl SlabAllocator {
     }
 
     #[must_use]
+    #[allow(unused)]
     pub fn caches(&self) -> &[SlabCacheType] {
         &self.caches
     }

--- a/src/arch/x86/vmm/allocators/kmalloc.rs
+++ b/src/arch/x86/vmm/allocators/kmalloc.rs
@@ -211,8 +211,14 @@ pub fn init_slab_allocator(allocator: &mut KernelAllocator) -> Result<(), Kmallo
     let mut cur = vaddr as *mut u8;
     for conf in SLAB_CONFIGS {
         let slab_cache_addr = NonNull::new(cur).ok_or(KmallocError::NotEnoughMemory)?;
+
+        // SAFETY:
+        // This is safe because we just allocated that space.
         unsafe { allocator.slab_allocator.init_slab_cache(slab_cache_addr, conf.object_size, SLABS_PER_CACHE) };
         let slab_size_bytes = PAGE_SIZE * conf.order * SLABS_PER_CACHE;
+
+        // SAFETY:
+        // This is safe because we just allocated that space.
         cur = unsafe { cur.add(slab_size_bytes) };
     }
 

--- a/src/arch/x86/vmm/allocators/kmalloc.rs
+++ b/src/arch/x86/vmm/allocators/kmalloc.rs
@@ -15,6 +15,7 @@ use crate::{
         init::mmap_init,
         page::PAGE_SIZE,
     },
+    boot::KERNEL_BASE,
     buddy_allocator_levels,
 };
 
@@ -163,18 +164,31 @@ pub fn buddy_allocator_free(addr: *const u8) -> Result<(), KfreeError> {
     unsafe { KERNEL_ALLOCATOR.buddy_allocator.free(addr) }
 }
 
+#[inline]
+const fn align_up(x: usize, align: usize) -> usize {
+    (x + align - 1) & !(align - 1)
+}
+
 /// # Errors
 /// This function will return an error if the initial allocation for the
 /// `BuddyAllocator` (made via `mmap`) fails.
 #[allow(static_mut_refs)]
 pub fn init_buddy_allocator(allocator: &mut KernelAllocator) -> Result<(), KmallocError> {
-    let kernel_end: usize = &raw const _kernel_end as usize;
-    let cache_memory = kernel_end;
-    mmap_init(cache_memory as *mut u8, None, BUDDY_ALLOCATOR_SIZE).map_err(|()| KmallocError::NotEnoughMemory)?;
+    let kernel_end_vaddr: usize = &raw const _kernel_end as usize;
+
+    // The buddy allocator requires its root to be naturally aligned to its
+    // total size — addresses inside the tree are derived from `root` purely
+    // by offset, so a misaligned root would have it hand out addresses
+    // outside the region (or with the buddy of the last block landing in
+    // unmapped memory). Round up.
+    let vaddr = align_up(kernel_end_vaddr, BUDDY_ALLOCATOR_SIZE);
+    let paddr = vaddr - KERNEL_BASE;
+
+    mmap_init(vaddr as *mut u8, Some(paddr as *mut u8), BUDDY_ALLOCATOR_SIZE).map_err(|()| KmallocError::NotEnoughMemory)?;
 
     allocator
         .buddy_allocator
-        .set_root(NonNull::new(cache_memory as *mut u8).ok_or(KmallocError::NotEnoughMemory)?);
+        .set_root(NonNull::new(vaddr as *mut u8).ok_or(KmallocError::NotEnoughMemory)?);
 
     Ok(())
 }
@@ -189,26 +203,25 @@ pub fn init_slab_allocator(allocator: &mut KernelAllocator) -> Result<(), Kmallo
 
     let total_size = SLAB_CONFIGS.iter().fold(0, |acc, conf| acc + PAGE_SIZE * conf.order * SLABS_PER_CACHE);
 
-    let kernel_end: usize = &raw const _kernel_end as usize;
-    let mut allocation = (kernel_end + BUDDY_ALLOCATOR_SIZE) as *mut u8;
-    mmap_init(allocation, None, total_size).map_err(|()| KmallocError::NotEnoughMemory)?;
+    let kernel_end_vaddr: usize = &raw const _kernel_end as usize;
+    // Slabs go right after the buddy region. The buddy region is aligned to
+    // its own size, so its end is also naturally aligned to BUDDY_ALLOCATOR_SIZE
+    // — far more than the slab region needs. PAGE_SIZE alignment is enough here.
+    let buddy_end = align_up(kernel_end_vaddr, BUDDY_ALLOCATOR_SIZE) + BUDDY_ALLOCATOR_SIZE;
+    let vaddr = buddy_end; // already page-aligned (BUDDY_ALLOCATOR_SIZE is a power of 2 ≥ PAGE_SIZE)
+    let paddr = vaddr - KERNEL_BASE;
 
-    allocator.slabs_start = allocation as usize;
-    allocator.slabs_end = allocation as usize + total_size;
+    mmap_init(vaddr as *mut u8, Some(paddr as *mut u8), total_size).map_err(|()| KmallocError::NotEnoughMemory)?;
 
+    allocator.slabs_start = vaddr;
+    allocator.slabs_end = vaddr + total_size;
+
+    let mut cur = vaddr as *mut u8;
     for conf in SLAB_CONFIGS {
-        let slab_cache_addr = NonNull::new(allocation).ok_or(KmallocError::NotEnoughMemory)?;
-        // SAFETY:
-        // This function is assumed to only ever be called once the buddy allocator is initialized, which
-        // would mean that the address we received from it is valid (otherwise we would have gotten an
-        // error).
+        let slab_cache_addr = NonNull::new(cur).ok_or(KmallocError::NotEnoughMemory)?;
         unsafe { allocator.slab_allocator.init_slab_cache(slab_cache_addr, conf.object_size, SLABS_PER_CACHE) };
         let slab_size_bytes = PAGE_SIZE * conf.order * SLABS_PER_CACHE;
-
-        // SAFETY:
-        // The bounds of this loop ensure we do not increment this pointer beyond the end of the allocation
-        // it points to.
-        allocation = unsafe { allocation.add(slab_size_bytes) };
+        cur = unsafe { cur.add(slab_size_bytes) };
     }
 
     Ok(())

--- a/src/arch/x86/vmm/allocators/kmalloc.rs
+++ b/src/arch/x86/vmm/allocators/kmalloc.rs
@@ -176,11 +176,6 @@ const fn align_up(x: usize, align: usize) -> usize {
 pub fn init_buddy_allocator(allocator: &mut KernelAllocator) -> Result<(), KmallocError> {
     let kernel_end_vaddr: usize = &raw const _kernel_end as usize;
 
-    // The buddy allocator requires its root to be naturally aligned to its
-    // total size — addresses inside the tree are derived from `root` purely
-    // by offset, so a misaligned root would have it hand out addresses
-    // outside the region (or with the buddy of the last block landing in
-    // unmapped memory). Round up.
     let vaddr = align_up(kernel_end_vaddr, BUDDY_ALLOCATOR_SIZE);
     let paddr = vaddr - KERNEL_BASE;
 
@@ -204,9 +199,6 @@ pub fn init_slab_allocator(allocator: &mut KernelAllocator) -> Result<(), Kmallo
     let total_size = SLAB_CONFIGS.iter().fold(0, |acc, conf| acc + PAGE_SIZE * conf.order * SLABS_PER_CACHE);
 
     let kernel_end_vaddr: usize = &raw const _kernel_end as usize;
-    // Slabs go right after the buddy region. The buddy region is aligned to
-    // its own size, so its end is also naturally aligned to BUDDY_ALLOCATOR_SIZE
-    // — far more than the slab region needs. PAGE_SIZE alignment is enough here.
     let buddy_end = align_up(kernel_end_vaddr, BUDDY_ALLOCATOR_SIZE) + BUDDY_ALLOCATOR_SIZE;
     let vaddr = buddy_end; // already page-aligned (BUDDY_ALLOCATOR_SIZE is a power of 2 ≥ PAGE_SIZE)
     let paddr = vaddr - KERNEL_BASE;

--- a/src/arch/x86/vmm/demand_pageing.rs
+++ b/src/arch/x86/vmm/demand_pageing.rs
@@ -1,4 +1,4 @@
-use core::intrinsics::copy_nonoverlapping;
+use core::ptr::copy_nonoverlapping;
 
 use crate::{
     arch::x86::{
@@ -12,18 +12,19 @@ use crate::{
 
 pub fn page_fault(regs: &mut InterruptRegisters) {
     serial_println!("page_fault: at addr {:x}", regs.cr2);
+    #[allow(clippy::missing_panics_doc)]
     let mut scheduler = SCHEDULER.lock().expect("page_fault | could not lock SCHEDULER");
 
     let addr = regs.cr2 as usize;
     let addr = ((addr + PAGE_SIZE - 1) / PAGE_SIZE) * PAGE_SIZE;
+    #[allow(clippy::missing_panics_doc)]
     let process = scheduler.current().expect("page_fault | no process running");
 
     for vma in &process.vmas {
         let access_allowed = vma.start <= addr && vma.start + vma.size > addr;
-        if access_allowed
-            && let Ok(()) = alloc_page(addr, &mut process.addressspace, vma) {
-                return;
-            }
+        if access_allowed && let Ok(()) = alloc_page(addr, &mut process.addressspace, vma) {
+            return;
+        }
     }
     drop(scheduler);
     sys_exit(regs);
@@ -43,6 +44,10 @@ fn alloc_page(vaddr: usize, space: &mut Addressspace, vma: &VMA) -> Result<(), (
     if let Some(offset) = vma.offset {
         space.map(temp, paddr, Permissions::ReadWrite);
         let diff = vaddr - vma.start;
+
+        // SAFETY:
+        // temp is a valid address because it just got mapped.
+        // offset + diff was validated when the binary was created.
         unsafe {
             copy_nonoverlapping((offset + diff) as *mut u8, temp, PAGE_SIZE);
         }

--- a/src/arch/x86/vmm/demand_pageing.rs
+++ b/src/arch/x86/vmm/demand_pageing.rs
@@ -1,0 +1,55 @@
+use core::intrinsics::copy_nonoverlapping;
+
+use crate::{
+    arch::x86::{
+        idt::InterruptRegisters,
+        scheduler::{Permissions, SCHEDULER},
+        syscall::sys_exit,
+        vmm::{PAGE_SIZE, addressspace::Addressspace, process::VMA, state::PAGE_ALLOCATOR},
+    },
+    serial_println,
+};
+
+pub fn page_fault(regs: &mut InterruptRegisters) {
+    serial_println!("page_fault: at addr {:x}", regs.cr2);
+    let mut scheduler = SCHEDULER.lock().expect("page_fault | could not lock SCHEDULER");
+
+    let addr = regs.cr2 as usize;
+    let addr = ((addr + PAGE_SIZE - 1) / PAGE_SIZE) * PAGE_SIZE;
+    let process = scheduler.current().expect("page_fault | no process running");
+
+    for vma in &process.vmas {
+        let access_allowed = vma.start <= addr && vma.start + vma.size > addr;
+        if access_allowed {
+            if let Ok(_) = alloc_page(addr, &mut process.addressspace, &vma) {
+                return;
+            }
+        }
+    }
+    drop(scheduler);
+    sys_exit(regs);
+}
+
+fn alloc_page(vaddr: usize, space: &mut Addressspace, vma: &VMA) -> Result<(), ()> {
+    let mut alloc = PAGE_ALLOCATOR.lock().expect("page_fault | could not lock PAGE_ALLOCATOR");
+    let paddr = match alloc.alloc(PAGE_SIZE) {
+        Some(paddr) => paddr,
+        None => {
+            return Err(());
+        }
+    };
+
+    let temp = 0xBFFF_F000 as *mut u8;
+
+    if let Some(offset) = vma.offset {
+        space.map(temp, paddr, Permissions::ReadWrite);
+        let diff = vaddr - vma.start;
+        unsafe {
+            copy_nonoverlapping((offset + diff) as *mut u8, temp, PAGE_SIZE);
+        }
+        space.unmap(temp);
+    }
+
+    space.map(vaddr as *mut u8, paddr, vma.permissions);
+    Ok(())
+}

--- a/src/arch/x86/vmm/demand_pageing.rs
+++ b/src/arch/x86/vmm/demand_pageing.rs
@@ -20,11 +20,10 @@ pub fn page_fault(regs: &mut InterruptRegisters) {
 
     for vma in &process.vmas {
         let access_allowed = vma.start <= addr && vma.start + vma.size > addr;
-        if access_allowed {
-            if let Ok(_) = alloc_page(addr, &mut process.addressspace, &vma) {
+        if access_allowed
+            && let Ok(()) = alloc_page(addr, &mut process.addressspace, vma) {
                 return;
             }
-        }
     }
     drop(scheduler);
     sys_exit(regs);

--- a/src/arch/x86/vmm/init.rs
+++ b/src/arch/x86/vmm/init.rs
@@ -153,6 +153,9 @@ fn map_kernel() -> Result<(), ()> {
     Ok(())
 }
 
+#[allow(clippy::missing_panics_doc)]
+/// # Safety
+/// Caller needs to ensure that the addr points to a proberly setup PageDirectyr
 pub unsafe fn load_page_directory(addr: *mut PageDirectory) {
     assert!(addr as usize % PAGE_SIZE == 0);
     // SAFETY:

--- a/src/arch/x86/vmm/page.rs
+++ b/src/arch/x86/vmm/page.rs
@@ -21,6 +21,12 @@ pub const PAGE_DIRECTORY_SIZE: usize = 1024;
 #[derive(Copy, Clone)]
 pub(super) struct PageDirectory(pub [PageDirectoryEntry; PAGE_DIRECTORY_SIZE]);
 
+impl PageDirectory {
+    pub fn empty() -> Self {
+        Self([PageDirectoryEntry::empty(); PAGE_DIRECTORY_SIZE])
+    }
+}
+
 impl core::ops::Deref for PageDirectory {
     type Target = [PageDirectoryEntry; PAGE_DIRECTORY_SIZE];
     fn deref(&self) -> &Self::Target {
@@ -38,6 +44,12 @@ pub const PAGE_TABLE_SIZE: usize = 1024;
 #[repr(align(0x1000))]
 #[derive(Copy, Clone)]
 pub(super) struct PageTable(pub [PageTableEntry; PAGE_TABLE_SIZE]);
+
+impl PageTable {
+    pub fn empty() -> Self {
+        Self([PageTableEntry::empty(); PAGE_TABLE_SIZE])
+    }
+}
 
 impl core::ops::Deref for PageTable {
     type Target = [PageTableEntry; PAGE_TABLE_SIZE];

--- a/src/arch/x86/vmm/page.rs
+++ b/src/arch/x86/vmm/page.rs
@@ -22,6 +22,7 @@ pub const PAGE_DIRECTORY_SIZE: usize = 1024;
 pub struct PageDirectory(pub [PageDirectoryEntry; PAGE_DIRECTORY_SIZE]);
 
 impl PageDirectory {
+    #[must_use]
     pub fn empty() -> Self {
         Self([PageDirectoryEntry::empty(); PAGE_DIRECTORY_SIZE])
     }
@@ -46,6 +47,7 @@ pub const PAGE_TABLE_SIZE: usize = 1024;
 pub struct PageTable(pub [PageTableEntry; PAGE_TABLE_SIZE]);
 
 impl PageTable {
+    #[must_use]
     pub fn empty() -> Self {
         Self([PageTableEntry::empty(); PAGE_TABLE_SIZE])
     }

--- a/src/arch/x86/vmm/page.rs
+++ b/src/arch/x86/vmm/page.rs
@@ -19,7 +19,7 @@ pub const PAGE_SIZE: usize = 0x1000;
 pub const PAGE_DIRECTORY_SIZE: usize = 1024;
 #[repr(align(0x1000))]
 #[derive(Copy, Clone)]
-pub(super) struct PageDirectory(pub [PageDirectoryEntry; PAGE_DIRECTORY_SIZE]);
+pub struct PageDirectory(pub [PageDirectoryEntry; PAGE_DIRECTORY_SIZE]);
 
 impl PageDirectory {
     pub fn empty() -> Self {
@@ -43,7 +43,7 @@ impl core::ops::DerefMut for PageDirectory {
 pub const PAGE_TABLE_SIZE: usize = 1024;
 #[repr(align(0x1000))]
 #[derive(Copy, Clone)]
-pub(super) struct PageTable(pub [PageTableEntry; PAGE_TABLE_SIZE]);
+pub struct PageTable(pub [PageTableEntry; PAGE_TABLE_SIZE]);
 
 impl PageTable {
     pub fn empty() -> Self {

--- a/src/arch/x86/vmm/page_allocator.rs
+++ b/src/arch/x86/vmm/page_allocator.rs
@@ -590,6 +590,7 @@ impl<'a> PageAllocator<'a> {
                     size,
                     pow2(order)
                 );
+                #[allow(clippy::missing_panics_doc)]
                 let node = self.orders[order][index].unwrap();
                 current = node.next();
             }

--- a/src/arch/x86/vmm/page_allocator.rs
+++ b/src/arch/x86/vmm/page_allocator.rs
@@ -187,7 +187,7 @@ pub(super) const ORDERS: usize = 20;
 /// backing arrays are `static mut` globals defined in
 /// [`crate::arch::x86::vmm::state`].
 #[derive(Debug)]
-pub(super) struct PageAllocator<'a> {
+pub struct PageAllocator<'a> {
     /// Per-order backing storage. `orders[o]` has `2^(20 - o)` entries
     /// except for `o == 19`, which has 2 entries so that the top of the
     /// tree can be represented without overflowing page-count arithmetic.

--- a/src/arch/x86/vmm/page_allocator.rs
+++ b/src/arch/x86/vmm/page_allocator.rs
@@ -97,7 +97,7 @@ use core::num::NonZeroU64;
 /// being set: `None` is represented by the all-zero bit pattern, so the
 /// backing arrays live in `.bss` and cost no ROM space.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct Node(NonZeroU64);
+pub struct Node(NonZeroU64);
 
 impl Node {
     /// The largest value representable in a 20-bit index field.

--- a/src/arch/x86/vmm/process.rs
+++ b/src/arch/x86/vmm/process.rs
@@ -1,10 +1,14 @@
 use alloc::{collections::VecDeque, vec::Vec};
 
-use crate::arch::x86::{idt::InterruptRegisters, vmm::addressspace::Addressspace};
+use crate::arch::x86::{
+    idt::InterruptRegisters,
+    scheduler::{Binary, Permissions},
+    vmm::addressspace::Addressspace,
+};
 
 pub type Pid = usize;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ProcessState {
     Running,
     Ready,
@@ -12,11 +16,50 @@ pub enum ProcessState {
     Zombie,
 }
 
+#[derive(Clone, Copy)]
+pub struct VMA {
+    pub start: usize,
+    pub offset: Option<usize>,
+    pub size: usize,
+    pub permissions: Permissions,
+}
+
 pub struct Process {
     pub pid: Pid,
     pub state: ProcessState,
     pub addressspace: Addressspace,
     pub saved_registers: InterruptRegisters,
+    pub vmas: Vec<VMA>,
+}
+
+impl Process {
+    pub fn new(binary: &Binary) -> Self {
+        Self {
+            pid: 0,
+            state: ProcessState::Ready,
+            addressspace: Addressspace::new(),
+            saved_registers: InterruptRegisters::new(binary.entry as u32, binary.stack as u32),
+            vmas: binary
+                .segments
+                .iter()
+                .map(|s| VMA {
+                    start: s.vaddr,
+                    offset: s.offset,
+                    size: s.size,
+                    permissions: s.permissions,
+                })
+                .collect(),
+        }
+    }
+    pub fn from_process(process: &mut Process) -> Self {
+        Self {
+            pid: 0,
+            state: ProcessState::Ready,
+            addressspace: process.addressspace.fork(),
+            saved_registers: process.saved_registers,
+            vmas: process.vmas.clone(),
+        }
+    }
 }
 
 pub struct ProcessTable {

--- a/src/arch/x86/vmm/process.rs
+++ b/src/arch/x86/vmm/process.rs
@@ -24,6 +24,7 @@ pub struct VMA {
     pub permissions: Permissions,
 }
 
+#[derive(Debug)]
 pub enum Parent {
     Root,
     Pid(Pid),

--- a/src/arch/x86/vmm/process.rs
+++ b/src/arch/x86/vmm/process.rs
@@ -1,0 +1,146 @@
+use alloc::{collections::VecDeque, vec::Vec};
+
+use crate::arch::x86::{idt::InterruptRegisters, vmm::addressspace::Addressspace};
+
+pub type Pid = usize;
+
+#[derive(Debug, PartialEq)]
+pub enum ProcessState {
+    Running,
+    Ready,
+    Blocked,
+    Zombie,
+}
+
+pub struct Process {
+    pub pid: Pid,
+    pub state: ProcessState,
+    pub addressspace: Addressspace,
+    pub saved_registers: InterruptRegisters,
+}
+
+pub struct ProcessTable {
+    processes: Vec<Option<Process>>,
+    free_slots: Vec<Pid>,
+}
+
+impl ProcessTable {
+    pub const fn new() -> Self {
+        Self {
+            processes: Vec::new(),
+            free_slots: Vec::new(),
+        }
+    }
+
+    pub fn insert(&mut self, mut proc: Process) -> Pid {
+        if let Some(pid) = self.free_slots.pop() {
+            proc.pid = pid;
+            self.processes[pid] = Some(proc);
+            pid
+        } else {
+            let pid = self.processes.len();
+            proc.pid = pid;
+            self.processes.push(Some(proc));
+            pid
+        }
+    }
+
+    pub fn remove(&mut self, pid: Pid) -> Option<Process> {
+        let slot = self.processes.get_mut(pid)?;
+        let proc = slot.take();
+        if proc.is_some() {
+            self.free_slots.push(pid);
+        }
+        proc
+    }
+
+    pub fn get(&self, pid: Pid) -> Option<&Process> {
+        self.processes.get(pid)?.as_ref()
+    }
+
+    pub fn get_mut(&mut self, pid: Pid) -> Option<&mut Process> {
+        self.processes.get_mut(pid)?.as_mut()
+    }
+}
+
+pub struct RunQueue {
+    queue: VecDeque<Pid>,
+}
+
+impl RunQueue {
+    pub const fn new() -> Self {
+        Self { queue: VecDeque::new() }
+    }
+
+    pub fn enqueue(&mut self, pid: Pid) {
+        self.queue.push_back(pid);
+    }
+
+    pub fn dequeue(&mut self) -> Option<Pid> {
+        self.queue.pop_front()
+    }
+
+    pub fn remove(&mut self, pid: Pid) {
+        self.queue.retain(|&p| p != pid);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+}
+
+pub struct Scheduler {
+    table: ProcessTable,
+    run_queue: RunQueue,
+    current: Option<Pid>,
+}
+
+impl Scheduler {
+    pub const fn new() -> Self {
+        Self {
+            table: ProcessTable::new(),
+            run_queue: RunQueue::new(),
+            current: None,
+        }
+    }
+
+    pub fn spawn(&mut self, proc: Process) -> Pid {
+        let pid = self.table.insert(proc);
+        self.run_queue.enqueue(pid);
+        pid
+    }
+
+    pub fn schedule(&mut self) -> Option<&mut Process> {
+        let pid = self.run_queue.dequeue()?;
+        self.run_queue.enqueue(pid); // round-robin
+        self.current = Some(pid);
+        self.table.get_mut(pid)
+    }
+
+    pub fn block(&mut self, pid: Pid) {
+        self.run_queue.remove(pid);
+        if let Some(proc) = self.table.get_mut(pid) {
+            proc.state = ProcessState::Blocked;
+        }
+    }
+
+    pub fn unblock(&mut self, pid: Pid) {
+        if let Some(proc) = self.table.get_mut(pid) {
+            proc.state = ProcessState::Ready;
+            self.run_queue.enqueue(pid);
+        }
+    }
+
+    pub fn exit(&mut self, pid: Pid) {
+        self.run_queue.remove(pid);
+        self.table.remove(pid);
+    }
+
+    pub fn current(&mut self) -> Option<&mut Process> {
+        self.table.get_mut(self.current?)
+    }
+}

--- a/src/arch/x86/vmm/process.rs
+++ b/src/arch/x86/vmm/process.rs
@@ -39,7 +39,7 @@ pub struct Process {
     pub vmas: Vec<VMA>,
     pub parent: Parent,
     pub children: Vec<Pid>,
-    pub ownerId: OwnerId,
+    pub owner_id: OwnerId,
 }
 
 impl Process {
@@ -62,7 +62,7 @@ impl Process {
                 .collect(),
             parent,
             children: Vec::new(),
-            ownerId: 0,
+            owner_id: 0,
         }
     }
     pub fn from_process(process: &mut Process) -> Self {
@@ -74,7 +74,7 @@ impl Process {
             vmas: process.vmas.clone(),
             parent: Parent::Pid(process.pid),
             children: Vec::new(),
-            ownerId: 0,
+            owner_id: 0,
         }
     }
 }

--- a/src/arch/x86/vmm/process.rs
+++ b/src/arch/x86/vmm/process.rs
@@ -7,6 +7,7 @@ use crate::arch::x86::{
 };
 
 pub type Pid = usize;
+pub type OwnerId = usize;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ProcessState {
@@ -37,6 +38,8 @@ pub struct Process {
     pub saved_registers: InterruptRegisters,
     pub vmas: Vec<VMA>,
     pub parent: Parent,
+    pub children: Vec<Pid>,
+    pub ownerId: OwnerId,
 }
 
 impl Process {
@@ -57,6 +60,8 @@ impl Process {
                 })
                 .collect(),
             parent,
+            children: Vec::new(),
+            ownerId: 0,
         }
     }
     pub fn from_process(process: &mut Process) -> Self {
@@ -67,6 +72,8 @@ impl Process {
             saved_registers: process.saved_registers,
             vmas: process.vmas.clone(),
             parent: Parent::Pid(process.pid),
+            children: Vec::new(),
+            ownerId: 0,
         }
     }
 }

--- a/src/arch/x86/vmm/process.rs
+++ b/src/arch/x86/vmm/process.rs
@@ -137,9 +137,9 @@ impl RunQueue {
 }
 
 pub struct Scheduler {
-    table: ProcessTable,
-    run_queue: RunQueue,
-    current: Option<Pid>,
+    pub table: ProcessTable,
+    pub run_queue: RunQueue,
+    pub current: Option<Pid>,
 }
 
 impl Scheduler {

--- a/src/arch/x86/vmm/process.rs
+++ b/src/arch/x86/vmm/process.rs
@@ -43,6 +43,7 @@ pub struct Process {
 }
 
 impl Process {
+    #[must_use]
     pub fn new(binary: &Binary, parent: Parent) -> Self {
         Self {
             pid: 0,
@@ -83,7 +84,14 @@ pub struct ProcessTable {
     free_slots: Vec<Pid>,
 }
 
+impl Default for ProcessTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ProcessTable {
+    #[must_use]
     pub const fn new() -> Self {
         Self {
             processes: Vec::new(),
@@ -113,6 +121,7 @@ impl ProcessTable {
         proc
     }
 
+    #[must_use]
     pub fn get(&self, pid: Pid) -> Option<&Process> {
         self.processes.get(pid)?.as_ref()
     }
@@ -126,7 +135,14 @@ pub struct RunQueue {
     queue: VecDeque<Pid>,
 }
 
+impl Default for RunQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RunQueue {
+    #[must_use]
     pub const fn new() -> Self {
         Self { queue: VecDeque::new() }
     }
@@ -143,10 +159,12 @@ impl RunQueue {
         self.queue.retain(|&p| p != pid);
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.queue.is_empty()
     }
 
+    #[must_use]
     pub fn len(&self) -> usize {
         self.queue.len()
     }
@@ -158,7 +176,14 @@ pub struct Scheduler {
     pub current: Option<Pid>,
 }
 
+impl Default for Scheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Scheduler {
+    #[must_use]
     pub const fn new() -> Self {
         Self {
             table: ProcessTable::new(),

--- a/src/arch/x86/vmm/process.rs
+++ b/src/arch/x86/vmm/process.rs
@@ -24,16 +24,22 @@ pub struct VMA {
     pub permissions: Permissions,
 }
 
+pub enum Parent {
+    Root,
+    Pid(Pid),
+}
+
 pub struct Process {
     pub pid: Pid,
     pub state: ProcessState,
     pub addressspace: Addressspace,
     pub saved_registers: InterruptRegisters,
     pub vmas: Vec<VMA>,
+    pub parent: Parent,
 }
 
 impl Process {
-    pub fn new(binary: &Binary) -> Self {
+    pub fn new(binary: &Binary, parent: Parent) -> Self {
         Self {
             pid: 0,
             state: ProcessState::Ready,
@@ -49,6 +55,7 @@ impl Process {
                     permissions: s.permissions,
                 })
                 .collect(),
+            parent,
         }
     }
     pub fn from_process(process: &mut Process) -> Self {
@@ -58,6 +65,7 @@ impl Process {
             addressspace: process.addressspace.fork(),
             saved_registers: process.saved_registers,
             vmas: process.vmas.clone(),
+            parent: Parent::Pid(process.pid),
         }
     }
 }

--- a/src/arch/x86/vmm/state.rs
+++ b/src/arch/x86/vmm/state.rs
@@ -1,6 +1,7 @@
 use crate::arch::x86::vmm::{
     page::{PAGE_DIRECTORY_SIZE, PAGE_TABLE_SIZE, PageDirectory, PageDirectoryEntry, PageTable, PageTableEntry},
     page_allocator::{Node, ORDERS, PageAllocator},
+    process::Scheduler,
 };
 
 use crate::arch::x86::kernel_mutex::KernelMutex;
@@ -137,3 +138,5 @@ pub(super) static PAGE_ALLOCATOR: KernelMutex<PageAllocator<'static>> = KernelMu
         h
     },
 ));
+
+pub static SCHEDULER: KernelMutex<Scheduler> = KernelMutex::new(Scheduler::new());

--- a/src/arch/x86/vmm/state.rs
+++ b/src/arch/x86/vmm/state.rs
@@ -138,5 +138,3 @@ pub(super) static PAGE_ALLOCATOR: KernelMutex<PageAllocator<'static>> = KernelMu
         h
     },
 ));
-
-pub static SCHEDULER: KernelMutex<Scheduler> = KernelMutex::new(Scheduler::new());

--- a/src/arch/x86/vmm/state.rs
+++ b/src/arch/x86/vmm/state.rs
@@ -101,7 +101,7 @@ pub(super) static mut PAGE_ALLOCATOR_ORDER_19: [Option<Node>; 1 << 1] = [const {
 ///   mut [Option<Node>]`.
 /// - `orders_head[20] = Some(0)` points at the single pre-seeded order-20 free block; every other
 ///   order starts empty.
-pub(super) static PAGE_ALLOCATOR: KernelMutex<PageAllocator<'static>> = KernelMutex::new(PageAllocator::new(
+pub static PAGE_ALLOCATOR: KernelMutex<PageAllocator<'static>> = KernelMutex::new(PageAllocator::new(
     // Safety:
     // We make sure that this is the only time we take a
     // reference to these arrays so that we only have

--- a/src/arch/x86/vmm/state.rs
+++ b/src/arch/x86/vmm/state.rs
@@ -1,7 +1,6 @@
 use crate::arch::x86::vmm::{
     page::{PAGE_DIRECTORY_SIZE, PAGE_TABLE_SIZE, PageDirectory, PageDirectoryEntry, PageTable, PageTableEntry},
     page_allocator::{Node, ORDERS, PageAllocator},
-    process::Scheduler,
 };
 
 use crate::arch::x86::kernel_mutex::KernelMutex;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,25 +32,27 @@ pub extern "C" fn kmain(_magic: usize, info: &MultibootInfo) {
     printkln!("Idt initialized");
     arch::x86::vmm::init(info);
     printkln!("Vmm initialized");
+    arch::x86::scheduler::init();
+    printkln!("Scheduler initialized");
 
     printkln!("Booted");
 
-    let mut a = Addressspace::new();
-    a.map(0x2000 as *mut u8, 0x2000_0000 as *mut u8, 1);
-    a.load();
-
-    let b = 3;
-    unsafe {
-        write_volatile(0x2000 as *mut u8, b);
-    }
-
-    unsafe {
-        kfs::serial_println!("{}", read_volatile(0x2000 as *mut u8));
-    }
-    a.map(0x2000 as *mut u8, 0x2000_1000 as *mut u8, 1);
-    unsafe {
-        kfs::serial_println!("{}", read_volatile(0x2000 as *mut u8));
-    }
+    // let mut a = Addressspace::new();
+    // a.map(0x2000 as *mut u8, 0x2000_0000 as *mut u8, 1);
+    // a.load();
+    //
+    // let b = 3;
+    // unsafe {
+    //     write_volatile(0x2000 as *mut u8, b);
+    // }
+    //
+    // unsafe {
+    //     kfs::serial_println!("{}", read_volatile(0x2000 as *mut u8));
+    // }
+    // a.map(0x2000 as *mut u8, 0x2000_1000 as *mut u8, 1);
+    // unsafe {
+    //     kfs::serial_println!("{}", read_volatile(0x2000 as *mut u8));
+    // }
     loop {
         spin_loop();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ unsafe extern "C" {
 }
 /// # Panics
 /// This function will panic if initialization of dynamic memory allocation fails.
-// #[cfg(not(test))]
+#[cfg(not(test))]
 #[unsafe(no_mangle)]
 pub extern "C" fn kmain(_magic: usize, info: &MultibootInfo) {
     use kfs::arch::{self, x86::vmm::addressspace::Addressspace};
@@ -37,43 +37,26 @@ pub extern "C" fn kmain(_magic: usize, info: &MultibootInfo) {
 
     printkln!("Booted");
 
-    // let mut a = Addressspace::new();
-    // a.map(0x2000 as *mut u8, 0x2000_0000 as *mut u8, 1);
-    // a.load();
-    //
-    // let b = 3;
-    // unsafe {
-    //     write_volatile(0x2000 as *mut u8, b);
-    // }
-    //
-    // unsafe {
-    //     kfs::serial_println!("{}", read_volatile(0x2000 as *mut u8));
-    // }
-    // a.map(0x2000 as *mut u8, 0x2000_1000 as *mut u8, 1);
-    // unsafe {
-    //     kfs::serial_println!("{}", read_volatile(0x2000 as *mut u8));
-    // }
     loop {
         spin_loop();
     }
-    // kfs::ps2::init();
 }
-//
-// /// # Panics
-// /// This function will panic if initialization of dynamic memory allocation fails.
-// #[cfg(test)]
-// #[unsafe(no_mangle)]
-// pub extern "C" fn kmain(_magic: usize, info: &MultibootInfo) {
-//     use kfs::{arch, qemu};
-//
-//     arch::x86::gdt::init();
-//     printkln!("Gdt initialized");
-//     arch::x86::idt::init();
-//     printkln!("Idt initialized");
-//     arch::x86::vmm::init(info);
-//     printkln!("Vmm initialized");
-//
-//     test_main();
-//
-//     unsafe { qemu::exit(qemu::ExitCode::Success) };
-// }
+
+/// # Panics
+/// This function will panic if initialization of dynamic memory allocation fails.
+#[cfg(test)]
+#[unsafe(no_mangle)]
+pub extern "C" fn kmain(_magic: usize, info: &MultibootInfo) {
+    use kfs::{arch, qemu};
+
+    arch::x86::gdt::init();
+    printkln!("Gdt initialized");
+    arch::x86::idt::init();
+    printkln!("Idt initialized");
+    arch::x86::vmm::init(info);
+    printkln!("Vmm initialized");
+
+    test_main();
+
+    unsafe { qemu::exit(qemu::ExitCode::Success) };
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,11 @@
 #![test_runner(kfs::tester::test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
-use core::hint::spin_loop;
+use core::{
+    alloc,
+    hint::spin_loop,
+    ptr::{read_volatile, write_volatile},
+};
 
 use kfs::{boot::MultibootInfo, printkln};
 
@@ -17,10 +21,10 @@ unsafe extern "C" {
 }
 /// # Panics
 /// This function will panic if initialization of dynamic memory allocation fails.
-#[cfg(not(test))]
+// #[cfg(not(test))]
 #[unsafe(no_mangle)]
 pub extern "C" fn kmain(_magic: usize, info: &MultibootInfo) {
-    use kfs::arch;
+    use kfs::arch::{self, x86::vmm::addressspace::Addressspace};
 
     arch::x86::gdt::init();
     printkln!("Gdt initialized");
@@ -31,27 +35,43 @@ pub extern "C" fn kmain(_magic: usize, info: &MultibootInfo) {
 
     printkln!("Booted");
 
+    let mut a = Addressspace::new();
+    a.map(0x2000 as *mut u8, 0x2000_0000 as *mut u8, 1);
+    a.load();
+
+    let b = 3;
+    unsafe {
+        write_volatile(0x2000 as *mut u8, b);
+    }
+
+    unsafe {
+        kfs::serial_println!("{}", read_volatile(0x2000 as *mut u8));
+    }
+    a.map(0x2000 as *mut u8, 0x2000_1000 as *mut u8, 1);
+    unsafe {
+        kfs::serial_println!("{}", read_volatile(0x2000 as *mut u8));
+    }
     loop {
         spin_loop();
     }
     // kfs::ps2::init();
 }
-
-/// # Panics
-/// This function will panic if initialization of dynamic memory allocation fails.
-#[cfg(test)]
-#[unsafe(no_mangle)]
-pub extern "C" fn kmain(_magic: usize, info: &MultibootInfo) {
-    use kfs::{arch, qemu};
-
-    arch::x86::gdt::init();
-    printkln!("Gdt initialized");
-    arch::x86::idt::init();
-    printkln!("Idt initialized");
-    arch::x86::vmm::init(info);
-    printkln!("Vmm initialized");
-
-    test_main();
-
-    unsafe { qemu::exit(qemu::ExitCode::Success) };
-}
+//
+// /// # Panics
+// /// This function will panic if initialization of dynamic memory allocation fails.
+// #[cfg(test)]
+// #[unsafe(no_mangle)]
+// pub extern "C" fn kmain(_magic: usize, info: &MultibootInfo) {
+//     use kfs::{arch, qemu};
+//
+//     arch::x86::gdt::init();
+//     printkln!("Gdt initialized");
+//     arch::x86::idt::init();
+//     printkln!("Idt initialized");
+//     arch::x86::vmm::init(info);
+//     printkln!("Vmm initialized");
+//
+//     test_main();
+//
+//     unsafe { qemu::exit(qemu::ExitCode::Success) };
+// }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,7 @@
 #![test_runner(kfs::tester::test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
-use core::{
-    alloc,
-    hint::spin_loop,
-    ptr::{read_volatile, write_volatile},
-};
+use core::hint::spin_loop;
 
 use kfs::{boot::MultibootInfo, printkln};
 
@@ -24,7 +20,7 @@ unsafe extern "C" {
 #[cfg(not(test))]
 #[unsafe(no_mangle)]
 pub extern "C" fn kmain(_magic: usize, info: &MultibootInfo) {
-    use kfs::arch::{self, x86::vmm::addressspace::Addressspace};
+    use kfs::arch::{self};
 
     arch::x86::gdt::init();
     printkln!("Gdt initialized");

--- a/src/ps2/interrupt.rs
+++ b/src/ps2/interrupt.rs
@@ -49,7 +49,7 @@ impl Buffer {
 }
 
 /// IRQ1
-extern "C" fn keyboard_interrupt_handler(_regs: &InterruptRegisters) {
+extern "C" fn keyboard_interrupt_handler(_regs: &mut InterruptRegisters) {
     let data_port = Port::new(DATA_PORT);
     let scancode = unsafe { data_port.read() };
 


### PR DESCRIPTION
This PR adds functionality for multi processing with some basic sycalls and page fault handling.
Exit is not working fully as expected but good enough for testing right now.
In the scheduler there are still some test functions.
And # Panics messages have been removed because the panics should crash if something goes wrong and are not out of the ordinary and would clutter the communication of functions that should be used elsewhere also.

<details>
  <summary>Rust API Guidelines Checklist</summary>
  
- **Naming** _(crate aligns with Rust naming conventions)_
    - [ ] Casing conforms to RFC 430 ([C-CASE](https://rust-lang.github.io/api-guidelines/naming.html#c-case))
    - [ ] Ad-hoc conversions follow `as_`, `to_`, `into_` conventions ([C-CONV](https://rust-lang.github.io/api-guidelines/naming.html#c-conv))
    - [ ] Getter names follow Rust convention ([C-GETTER](https://rust-lang.github.io/api-guidelines/naming.html#c-getter))
    - [ ] Methods on collections that produce iterators follow `iter`, `iter_mut`, `into_iter` ([C-ITER](https://rust-lang.github.io/api-guidelines/naming.html#c-iter))
    - [ ] Iterator type names match the methods that produce them ([C-ITER-TY](https://rust-lang.github.io/api-guidelines/naming.html#c-iter-ty))
    - [ ] Feature names are free of placeholder words ([C-FEATURE](https://rust-lang.github.io/api-guidelines/naming.html#c-feature))
    - [ ] Names use a consistent word order ([C-WORD-ORDER](https://rust-lang.github.io/api-guidelines/naming.html#c-word-order))
- **Interoperability** _(crate interacts nicely with other library functionality)_
    - [ ] Types eagerly implement common traits ([C-COMMON-TRAITS](https://rust-lang.github.io/api-guidelines/interoperability.html#c-common-traits))
        - `Copy`, `Clone`, `Eq`, `PartialEq`, `Ord`, `PartialOrd`, `Hash`, `Debug`,
          `Display`, `Default`
    - [ ] Conversions use the standard traits `From`, `AsRef`, `AsMut` ([C-CONV-TRAITS](https://rust-lang.github.io/api-guidelines/interoperability.html#c-conv-traits))
    - [ ] Collections implement `FromIterator` and `Extend` ([C-COLLECT](https://rust-lang.github.io/api-guidelines/interoperability.html#c-collect))
    - [ ] Data structures implement Serde's `Serialize`, `Deserialize` ([C-SERDE](https://rust-lang.github.io/api-guidelines/interoperability.html#c-serde))
    - [ ] Types are `Send` and `Sync` where possible ([C-SEND-SYNC](https://rust-lang.github.io/api-guidelines/interoperability.html#c-send-sync))
    - [ ] Error types are meaningful and well-behaved ([C-GOOD-ERR](https://rust-lang.github.io/api-guidelines/interoperability.html#c-good-err))
    - [ ] Binary number types provide `Hex`, `Octal`, `Binary` formatting ([C-NUM-FMT](https://rust-lang.github.io/api-guidelines/interoperability.html#c-num-fmt))
    - [ ] Generic reader/writer functions take `R: Read` and `W: Write` by value ([C-RW-VALUE](https://rust-lang.github.io/api-guidelines/interoperability.html#c-rw-value))
- **Macros** _(crate presents well-behaved macros)_
    - [ ] Input syntax is evocative of the output ([C-EVOCATIVE](https://rust-lang.github.io/api-guidelines/macros.html#c-evocative))
    - [ ] Macros compose well with attributes ([C-MACRO-ATTR](https://rust-lang.github.io/api-guidelines/macros.html#c-macro-attr))
    - [ ] Item macros work anywhere that items are allowed ([C-ANYWHERE](https://rust-lang.github.io/api-guidelines/macros.html#c-anywhere))
    - [ ] Item macros support visibility specifiers ([C-MACRO-VIS](https://rust-lang.github.io/api-guidelines/macros.html#c-macro-vis))
    - [ ] Type fragments are flexible ([C-MACRO-TY](https://rust-lang.github.io/api-guidelines/macros.html#c-macro-ty))
- **Documentation** _(crate is abundantly documented)_
    - [ ] Crate level docs are thorough and include examples ([C-CRATE-DOC](https://rust-lang.github.io/api-guidelines/documentation.html#c-crate-doc))
    - [ ] All items have a rustdoc example ([C-EXAMPLE](https://rust-lang.github.io/api-guidelines/documentation.html#c-example))
    - [ ] Examples use `?`, not `try!`, not `unwrap` ([C-QUESTION-MARK](https://rust-lang.github.io/api-guidelines/documentation.html#c-question-mark))
    - [ ] Function docs include error, panic, and safety considerations ([C-FAILURE](https://rust-lang.github.io/api-guidelines/documentation.html#c-failure))
    - [ ] Prose contains hyperlinks to relevant things ([C-LINK](https://rust-lang.github.io/api-guidelines/documentation.html#c-link))
    - [ ] Cargo.toml includes all common metadata ([C-METADATA](https://rust-lang.github.io/api-guidelines/documentation.html#c-metadata))
        - authors, description, license, homepage, documentation, repository,
          keywords, categories
    - [ ] Release notes document all significant changes ([C-RELNOTES](https://rust-lang.github.io/api-guidelines/documentation.html#c-relnotes))
    - [ ] Rustdoc does not show unhelpful implementation details ([C-HIDDEN](https://rust-lang.github.io/api-guidelines/documentation.html#c-hidden))
- **Predictability** _(crate enables legible code that acts how it looks)_
    - [ ] Smart pointers do not add inherent methods ([C-SMART-PTR](https://rust-lang.github.io/api-guidelines/documentation.html#c-smart-ptr))
    - [ ] Conversions live on the most specific type involved ([C-CONV-SPECIFIC](https://rust-lang.github.io/api-guidelines/documentation.html#c-cow-specific))
    - [ ] Functions with a clear receiver are methods ([C-METHOD](https://rust-lang.github.io/api-guidelines/documentation.html#c-method))
    - [ ] Functions do not take out-parameters ([C-NO-OUT](https://rust-lang.github.io/api-guidelines/documentation.html#c-no-out))
    - [ ] Operator overloads are unsurprising ([C-OVERLOAD](https://rust-lang.github.io/api-guidelines/documentation.html#c-overload))
    - [ ] Only smart pointers implement `Deref` and `DerefMut` ([C-DEREF](https://rust-lang.github.io/api-guidelines/documentation.html#c-deref))
    - [ ] Constructors are static, inherent methods ([C-CTOR](https://rust-lang.github.io/api-guidelines/documentation.html#c-ctor))
- **Flexibility** _(crate supports diverse real-world use cases)_
    - [ ] Functions expose intermediate results to avoid duplicate work ([C-INTERMEDIATE](https://rust-lang.github.io/api-guidelines/documentation.html#c-intermediate))
    - [ ] Caller decides where to copy and place data ([C-CALLER-CONTROL](https://rust-lang.github.io/api-guidelines/documentation.html#c-caller-control))
    - [ ] Functions minimize assumptions about parameters by using generics ([C-GENERIC](https://rust-lang.github.io/api-guidelines/documentation.html#c-generic))
    - [ ] Traits are object-safe if they may be useful as a trait object ([C-OBJECT](https://rust-lang.github.io/api-guidelines/documentation.html#c-object))
- **Type safety** _(crate leverages the type system effectively)_
    - [ ] Newtypes provide static distinctions ([C-NEWTYPE](https://rust-lang.github.io/api-guidelines/documentation.html#c-newtype))
    - [ ] Arguments convey meaning through types, not `bool` or `Option` ([C-CUSTOM-TYPE](https://rust-lang.github.io/api-guidelines/documentation.html#c-custom-type))
    - [ ] Types for a set of flags are `bitflags`, not enums ([C-BITFLAG](https://rust-lang.github.io/api-guidelines/documentation.html#c-bitflags))
    - [ ] Builders enable construction of complex values ([C-BUILDER](https://rust-lang.github.io/api-guidelines/documentation.html#c-builder))
- **Dependability** _(crate is unlikely to do the wrong thing)_
    - [ ] Functions validate their arguments ([C-VALIDATE](https://rust-lang.github.io/api-guidelines/documentation.html#c-validate))
    - [ ] Destructors never fail ([C-DTOR-FAIL](https://rust-lang.github.io/api-guidelines/documentation.html#c-dtor-fail))
    - [ ] Destructors that may block have alternatives ([C-DTOR-BLOCK](https://rust-lang.github.io/api-guidelines/documentation.html#c-dtor-block))
- **Debuggability** _(crate is conducive to easy debugging)_
    - [ ] All public types implement `Debug` ([C-DEBUG](https://rust-lang.github.io/api-guidelines/documentation.html#c-debug))
    - [ ] `Debug` representation is never empty ([C-DEBUG-NONEMPTY](https://rust-lang.github.io/api-guidelines/documentation.html#c-debug-nonempty))
- **Future proofing** _(crate is free to improve without breaking users' code)_
    - [ ] Sealed traits protect against downstream implementations ([C-SEALED](https://rust-lang.github.io/api-guidelines/documentation.html#c-sealed))
    - [ ] Structs have private fields ([C-STRUCT-PRIVATE](https://rust-lang.github.io/api-guidelines/documentation.html#c-struct-private))
    - [ ] Newtypes encapsulate implementation details ([C-NEWTYPE-HIDE](https://rust-lang.github.io/api-guidelines/documentation.html#c-newtype-hide))
    - [ ] Data structures do not duplicate derived trait bounds ([C-STRUCT-BOUNDS](https://rust-lang.github.io/api-guidelines/documentation.html#c-struct-bounds))
- **Necessities** _(to whom they matter, they really matter)_
    - [ ] Public dependencies of a stable crate are stable ([C-STABLE](https://rust-lang.github.io/api-guidelines/documentation.html#c-stable))
    - [ ] Crate and its dependencies have a permissive license ([C-PERMISSIVE](https://rust-lang.github.io/api-guidelines/documentation.html#c-permissive))

</details>

