### PR TITLE
Fbruggem/kfs 5/ipc

### DIFF
--- a/src/arch/x86/scheduler.rs
+++ b/src/arch/x86/scheduler.rs
@@ -50,11 +50,7 @@ extern "C" fn program_write_in_memory() {
         "int 0x80",
     );
 }
-//
-// #[unsafe(naked)]
-// extern "C" fn program_ipc_test_sender() {
-//     // naked_asm!()
-// }
+
 #[unsafe(naked)]
 extern "C" fn program_ipc_test() {
     naked_asm!(
@@ -77,7 +73,7 @@ extern "C" fn program_ipc_test() {
         // edi is now the child_id
 
         // Store pid at [0x2000] so we have a stable address to pass as buf.
-        "mov dword ptr [0x2000], edi",
+        "mov dword ptr [0x2000], 0x696969",
         // socket_write(fd=esi, buf=0x2000, len=4)
         "mov eax, 8",
         "mov ebx, esi",

--- a/src/arch/x86/scheduler.rs
+++ b/src/arch/x86/scheduler.rs
@@ -54,6 +54,13 @@ extern "C" fn program_write_in_memory() {
 #[unsafe(naked)]
 extern "C" fn program_ipc_test() {
     naked_asm!(
+        "mov eax, 99",
+        "int 0x80",
+        "mov ebx, eax",
+        "mov eax, 42",
+        "int 0x80",
+        "loping:",
+        "jmp loping",
         // --- socket_create() -> eax = fd ---
         "mov eax, 5",
         "int 0x80",
@@ -105,6 +112,8 @@ extern "C" fn program_ipc_test() {
         "mov eax, 42",
         "int 0x80",
         //
+        "mov eax, 57",
+        "int 0x80",
         "mov eax, 60",
         "int 0x80",
     );
@@ -197,7 +206,7 @@ pub fn init() {
         size: 0x1000,
         permissions: Permissions::ReadWrite,
     });
-    let p = Process::new(&bin, super::vmm::process::Parent::Root);
+    let p = Process::new(&bin, super::vmm::process::Parent::Root, false);
     SCHEDULER.lock().unwrap().spawn(p);
 
     irq::install_handler(0, timer);

--- a/src/arch/x86/scheduler.rs
+++ b/src/arch/x86/scheduler.rs
@@ -42,8 +42,74 @@ extern "C" fn program_write_in_memory() {
         // overwrite with 0xBBBB - this should NOT affect the parent
         "mov dword ptr [0x2000], 0xBBBB",
         "done:",
-        // both processes read their own [0x2000] into ebx and exit
         "mov ebx, [0x2000]",
+        "mov eax, 42",
+        "int 0x80",
+        // both processes read their own [0x2000] into ebx and exit
+        "mov eax, 60",
+        "int 0x80",
+    );
+}
+//
+// #[unsafe(naked)]
+// extern "C" fn program_ipc_test_sender() {
+//     // naked_asm!()
+// }
+#[unsafe(naked)]
+extern "C" fn program_ipc_test() {
+    naked_asm!(
+        // --- socket_create() -> eax = fd ---
+        "mov eax, 5",
+        "int 0x80",
+        // save fd in esi (callee-saved-ish for our purposes; nothing clobbers
+        // it until we use it again).
+        "mov esi, eax",
+        //
+        // --- fork() ---
+        "mov eax, 57",
+        "int 0x80",
+        //
+        //
+        // branch on eax: 0 = child, nonzero = parent
+        "test eax, eax",
+        "jz child",
+        "mov edi, eax",
+        // edi is now the child_id
+
+        // Store pid at [0x2000] so we have a stable address to pass as buf.
+        "mov dword ptr [0x2000], edi",
+        // socket_write(fd=esi, buf=0x2000, len=4)
+        "mov eax, 8",
+        "mov ebx, esi",
+        "mov ecx, 0x2000",
+        "mov edx, 4",
+        "int 0x80",
+        "mov ebx, eax",
+        "mov eax, 42",
+        "int 0x80",
+        // exit(0). ebx = 0 so the parent's exit log is unambiguous.
+        "mov eax, 60",
+        "mov ebx, 0",
+        "int 0x80",
+        // ===== CHILD =====
+        "child:",
+        // Busy-loop on socket_read until it returns > 0.
+        // (No blocking read yet, so we spin.)
+        "retry:",
+        "mov eax, 7",
+        "mov ebx, esi",
+        "mov ecx, 0x2000",
+        "mov edx, 4",
+        "int 0x80",
+        // eax = bytes read. If 0, retry.
+        "test eax, eax",
+        "jz retry",
+        // Load the received value into ebx and exit, so sys_exit prints it.
+        "mov ebx, [0x2000]",
+        //
+        "mov eax, 42",
+        "int 0x80",
+        //
         "mov eax, 60",
         "int 0x80",
     );
@@ -111,21 +177,32 @@ static TWO: u32 = 2;
 
 #[allow(clippy::missing_panics_doc)]
 pub fn init() {
-    let mut init = Binary::new(0x1000, 0x2000);
-    init.segments.push(Segment {
-        offset: Some(program_write_in_memory as *const () as usize),
+    let mut bin = Binary::new(0x1000, 0x3000);
+
+    // Code page: ipc test program.
+    bin.segments.push(Segment {
+        offset: Some(program_ipc_test as *const () as usize),
         vaddr: 0x1000,
         size: 0x1000,
         permissions: Permissions::Read,
     });
-    init.segments.push(Segment {
-        offset: Some(&raw const ONE as usize),
+
+    // Data page used as the IPC payload buffer at 0x2000.
+    bin.segments.push(Segment {
+        offset: None,
         vaddr: 0x2000,
         size: 0x1000,
         permissions: Permissions::ReadWrite,
     });
 
-    let p = Process::new(&init, super::vmm::process::Parent::Root);
+    // Stack page.
+    bin.segments.push(Segment {
+        offset: None,
+        vaddr: 0x3000,
+        size: 0x1000,
+        permissions: Permissions::ReadWrite,
+    });
+    let p = Process::new(&bin, super::vmm::process::Parent::Root);
     SCHEDULER.lock().unwrap().spawn(p);
 
     irq::install_handler(0, timer);
@@ -145,7 +222,7 @@ pub extern "C" fn timer(regs: &mut InterruptRegisters) {
     }
 
     // find the next process
-    let next = scheduler.schedule().expect("no process to run");
+    let next = scheduler.schedule().expect("could not lock SCHEDULER");
 
     next.state = crate::arch::x86::vmm::process::ProcessState::Running;
     next.addressspace.load();

--- a/src/arch/x86/scheduler.rs
+++ b/src/arch/x86/scheduler.rs
@@ -84,9 +84,8 @@ extern "C" fn program_ipc_test() {
         "mov eax, 42",
         "int 0x80",
         // exit(0). ebx = 0 so the parent's exit log is unambiguous.
-        "mov eax, 60",
-        "mov ebx, 0",
-        "int 0x80",
+        "looping:",
+        "jmp looping",
         // ===== CHILD =====
         "child:",
         // Busy-loop on socket_read until it returns > 0.
@@ -214,6 +213,7 @@ pub extern "C" fn timer(regs: &mut InterruptRegisters) {
     let mut scheduler = SCHEDULER.lock().expect("timer | failed to lock SCHEDULER");
     // first save the registers if there was a running process
     if let Some(p) = scheduler.current() {
+        serial_println!("processssss children {:?}", p.children_stopped);
         p.saved_registers = *regs;
     }
 

--- a/src/arch/x86/scheduler.rs
+++ b/src/arch/x86/scheduler.rs
@@ -14,11 +14,12 @@ use crate::{
     serial_println,
 };
 
-#[unsafe(naked)]
-#[allow(unused)]
-extern "C" fn program_exit() {
-    naked_asm!("aaa:", "mov eax, 60", "int 0x80", "jmp aaa");
-}
+// #[unsafe(naked)]
+// #[allow(unused)]
+// extern "C" fn program_exit() {
+//     naked_asm!("aaa:", "mov eax, 60", "int 0x80", "jmp aaa");
+// }
+
 #[unsafe(naked)]
 extern "C" fn program_wait() {
     naked_asm!(
@@ -47,103 +48,104 @@ extern "C" fn program_wait() {
         "int 0x80",
     );
 }
-#[unsafe(naked)]
-extern "C" fn program_write_in_memory() {
-    naked_asm!(
-        // both processes start by writing the same initial value
-        "mov dword ptr [0x2000], 0x42",
-        // fork
-        "mov eax, 57",
-        "int 0x80",
-        // after this: eax = 0 in child, eax = child_pid in parent
 
-        // branch on eax
-        "test eax, eax",
-        "jz child",
-        // ----- parent path -----
-        // overwrite with 0xAAAA - this should NOT affect the child
-        "mov dword ptr [0x2000], 0xAAAA",
-        "jmp done",
-        "child:",
-        // ----- child path -----
-        // overwrite with 0xBBBB - this should NOT affect the parent
-        "mov dword ptr [0x2000], 0xBBBB",
-        "done:",
-        "mov ebx, [0x2000]",
-        "mov eax, 42",
-        "int 0x80",
-        // both processes read their own [0x2000] into ebx and exit
-        "mov eax, 60",
-        "int 0x80",
-    );
-}
-
-#[unsafe(naked)]
-extern "C" fn program_ipc_test() {
-    naked_asm!(
-        "mov eax, 99",
-        "int 0x80",
-        "mov ebx, eax",
-        "mov eax, 42",
-        "int 0x80",
-        // --- socket_create() -> eax = fd ---
-        "mov eax, 5",
-        "int 0x80",
-        // save fd in esi (callee-saved-ish for our purposes; nothing clobbers
-        // it until we use it again).
-        "mov esi, eax",
-        //
-        // --- fork() ---
-        "mov eax, 57",
-        "int 0x80",
-        //
-        //
-        // branch on eax: 0 = child, nonzero = parent
-        "test eax, eax",
-        "jz child",
-        "mov edi, eax",
-        // edi is now the child_id
-
-        // Store pid at [0x2000] so we have a stable address to pass as buf.
-        "mov dword ptr [0x2000], 0x696969",
-        // socket_write(fd=esi, buf=0x2000, len=4)
-        "mov eax, 8",
-        "mov ebx, esi",
-        "mov ecx, 0x2000",
-        "mov edx, 4",
-        "int 0x80",
-        "mov ebx, eax",
-        "mov eax, 42",
-        "int 0x80",
-        // exit(0). ebx = 0 so the parent's exit log is unambiguous.
-        "looping:",
-        "jmp looping",
-        // ===== CHILD =====
-        "child:",
-        // Busy-loop on socket_read until it returns > 0.
-        // (No blocking read yet, so we spin.)
-        "retry:",
-        "mov eax, 7",
-        "mov ebx, esi",
-        "mov ecx, 0x2000",
-        "mov edx, 4",
-        "int 0x80",
-        // eax = bytes read. If 0, retry.
-        "test eax, eax",
-        "jz retry",
-        // Load the received value into ebx and exit, so sys_exit prints it.
-        "mov ebx, [0x2000]",
-        //
-        "mov eax, 42",
-        "int 0x80",
-        //
-        "mov eax, 57",
-        "int 0x80",
-        "mov eax, 60",
-        "int 0x80",
-    );
-}
-
+// #[unsafe(naked)]
+// extern "C" fn program_write_in_memory() {
+//     naked_asm!(
+//         // both processes start by writing the same initial value
+//         "mov dword ptr [0x2000], 0x42",
+//         // fork
+//         "mov eax, 57",
+//         "int 0x80",
+//         // after this: eax = 0 in child, eax = child_pid in parent
+//
+//         // branch on eax
+//         "test eax, eax",
+//         "jz child",
+//         // ----- parent path -----
+//         // overwrite with 0xAAAA - this should NOT affect the child
+//         "mov dword ptr [0x2000], 0xAAAA",
+//         "jmp done",
+//         "child:",
+//         // ----- child path -----
+//         // overwrite with 0xBBBB - this should NOT affect the parent
+//         "mov dword ptr [0x2000], 0xBBBB",
+//         "done:",
+//         "mov ebx, [0x2000]",
+//         "mov eax, 42",
+//         "int 0x80",
+//         // both processes read their own [0x2000] into ebx and exit
+//         "mov eax, 60",
+//         "int 0x80",
+//     );
+// }
+//
+// #[unsafe(naked)]
+// extern "C" fn program_ipc_test() {
+//     naked_asm!(
+//         "mov eax, 99",
+//         "int 0x80",
+//         "mov ebx, eax",
+//         "mov eax, 42",
+//         "int 0x80",
+//         // --- socket_create() -> eax = fd ---
+//         "mov eax, 5",
+//         "int 0x80",
+//         // save fd in esi (callee-saved-ish for our purposes; nothing clobbers
+//         // it until we use it again).
+//         "mov esi, eax",
+//         //
+//         // --- fork() ---
+//         "mov eax, 57",
+//         "int 0x80",
+//         //
+//         //
+//         // branch on eax: 0 = child, nonzero = parent
+//         "test eax, eax",
+//         "jz child",
+//         "mov edi, eax",
+//         // edi is now the child_id
+//
+//         // Store pid at [0x2000] so we have a stable address to pass as buf.
+//         "mov dword ptr [0x2000], 0x696969",
+//         // socket_write(fd=esi, buf=0x2000, len=4)
+//         "mov eax, 8",
+//         "mov ebx, esi",
+//         "mov ecx, 0x2000",
+//         "mov edx, 4",
+//         "int 0x80",
+//         "mov ebx, eax",
+//         "mov eax, 42",
+//         "int 0x80",
+//         // exit(0). ebx = 0 so the parent's exit log is unambiguous.
+//         "looping:",
+//         "jmp looping",
+//         // ===== CHILD =====
+//         "child:",
+//         // Busy-loop on socket_read until it returns > 0.
+//         // (No blocking read yet, so we spin.)
+//         "retry:",
+//         "mov eax, 7",
+//         "mov ebx, esi",
+//         "mov ecx, 0x2000",
+//         "mov edx, 4",
+//         "int 0x80",
+//         // eax = bytes read. If 0, retry.
+//         "test eax, eax",
+//         "jz retry",
+//         // Load the received value into ebx and exit, so sys_exit prints it.
+//         "mov ebx, [0x2000]",
+//         //
+//         "mov eax, 42",
+//         "int 0x80",
+//         //
+//         "mov eax, 57",
+//         "int 0x80",
+//         "mov eax, 60",
+//         "int 0x80",
+//     );
+// }
+//
 // #[unsafe(naked)]
 // extern "C" fn program() {
 //     naked_asm!(

--- a/src/arch/x86/scheduler.rs
+++ b/src/arch/x86/scheduler.rs
@@ -9,7 +9,7 @@ use crate::{
         idt::InterruptRegisters,
         interrupts::irq,
         kernel_mutex::KernelMutex,
-        vmm::process::{Process, Scheduler},
+        vmm::process::{Process, ProcessState, Scheduler},
     },
     serial_println,
 };
@@ -19,7 +19,34 @@ use crate::{
 extern "C" fn program_exit() {
     naked_asm!("aaa:", "mov eax, 60", "int 0x80", "jmp aaa");
 }
+#[unsafe(naked)]
+extern "C" fn program_wait() {
+    naked_asm!(
+        // fork
+        "mov eax, 57",
+        "int 0x80",
+        // after this: eax = 0 in child, eax = child_pid in parent
 
+        // branch on eax
+        "test eax, eax",
+        "jz child",
+        "mov eax, 98",
+        "int 0x80",
+        "mov ebx, eax",
+        "mov eax, 42",
+        "int 0x80",
+        "mov eax, 60",
+        "int 0x80",
+        "child:",
+        "mov ecx, 100000000",
+        "delay_loop:",
+        "dec ecx",
+        "jnz delay_loop",
+        // ----- child path -----
+        "mov eax, 60",
+        "int 0x80",
+    );
+}
 #[unsafe(naked)]
 extern "C" fn program_write_in_memory() {
     naked_asm!(
@@ -59,8 +86,6 @@ extern "C" fn program_ipc_test() {
         "mov ebx, eax",
         "mov eax, 42",
         "int 0x80",
-        "loping:",
-        "jmp loping",
         // --- socket_create() -> eax = fd ---
         "mov eax, 5",
         "int 0x80",
@@ -185,7 +210,7 @@ pub fn init() {
 
     // Code page: ipc test program.
     bin.segments.push(Segment {
-        offset: Some(program_ipc_test as *const () as usize),
+        offset: Some(program_wait as *const () as usize),
         vaddr: 0x1000,
         size: 0x1000,
         permissions: Permissions::Read,
@@ -206,6 +231,7 @@ pub fn init() {
         size: 0x1000,
         permissions: Permissions::ReadWrite,
     });
+
     let p = Process::new(&bin, super::vmm::process::Parent::Root, false);
     SCHEDULER.lock().unwrap().spawn(p);
 
@@ -222,14 +248,24 @@ pub extern "C" fn timer(regs: &mut InterruptRegisters) {
     let mut scheduler = SCHEDULER.lock().expect("timer | failed to lock SCHEDULER");
     // first save the registers if there was a running process
     if let Some(p) = scheduler.current() {
-        serial_println!("processssss children {:?}", p.children_stopped);
         p.saved_registers = *regs;
     }
 
     // find the next process
-    let next = scheduler.schedule().expect("could not lock SCHEDULER");
-
-    next.state = crate::arch::x86::vmm::process::ProcessState::Running;
-    next.addressspace.load();
-    *regs = next.saved_registers;
+    loop {
+        let next = scheduler.schedule().expect("could not lock SCHEDULER");
+        if next.state == ProcessState::Waiting {
+            if let Some(child_stopped_id) = next.children_stopped.pop() {
+                next.state = crate::arch::x86::vmm::process::ProcessState::Running;
+                next.addressspace.load();
+                *regs = next.saved_registers;
+                regs.eax = child_stopped_id as u32;
+                return;
+            }
+            continue;
+        }
+        next.addressspace.load();
+        *regs = next.saved_registers;
+        break;
+    }
 }

--- a/src/arch/x86/syscall.rs
+++ b/src/arch/x86/syscall.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::expect_used)]
 #![allow(clippy::missing_panics_doc)]
+use alloc::format;
+
 use crate::{
     arch::x86::{
         idt::InterruptRegisters,
@@ -7,13 +9,14 @@ use crate::{
         vmm::process::Process,
     },
     serial_println,
+    socket::{socket_close, socket_create, socket_read, socket_write},
 };
 
 pub extern "C" fn sys_exit(regs: &mut InterruptRegisters) {
-    serial_println!("exited while ebx was {}", regs.ebx);
     let mut scheduler = SCHEDULER.lock().expect("timer | failed to lock SCHEDULER");
 
     let pid = scheduler.current().expect("sys_exit | no process running").pid;
+    serial_println!("pid {} exited", pid);
 
     scheduler.exit(pid);
 
@@ -47,9 +50,114 @@ pub fn sys_getpid(regs: &mut InterruptRegisters) {
     regs.eax = cur.pid as u32;
 }
 
+pub fn sys_socket_create(regs: &mut InterruptRegisters) {
+    // Create the underlying socket first, then install it in the current
+    // process's fd table. Two locks, never held at the same time.
+
+    let sid = socket_create();
+
+    let mut scheduler = SCHEDULER.lock().expect("sys_socket_create | could not lock SCHEDULER");
+    let process = scheduler.current().expect("sys_socket_create | no process running");
+    let fd = process.install_socket(sid);
+    regs.eax = fd as u32;
+}
+
+pub fn sys_socket_close(regs: &mut InterruptRegisters) {
+    let fd = regs.ebx as usize;
+
+    // Remove the fd from the process, then drop the scheduler lock before
+    // touching the global socket table.
+    let sid = {
+        let mut scheduler = SCHEDULER.lock().expect("sys_socket_close | could not lock SCHEDULER");
+        let process = scheduler.current().expect("sys_socket_close | no process running");
+        process.remove_socket(fd)
+    };
+
+    regs.eax = match sid {
+        None => u32::MAX,
+        Some(sid) => match socket_close(sid) {
+            Ok(()) => 0,
+            Err(e) => u32::MAX,
+        },
+    };
+}
+
+pub fn sys_socket_write(regs: &mut InterruptRegisters) {
+    let fd = regs.ebx as usize;
+    let buf = regs.ecx as usize;
+    let len = regs.edx as usize;
+
+    // Snapshot fd → SocketId + VMAs, then release SCHEDULER before the copy.
+    let (sid, vmas) = {
+        let mut scheduler = SCHEDULER.lock().expect("sys_socket_write | could not lock SCHEDULER");
+        let process = scheduler.current().expect("sys_socket_write | no process running");
+        (process.resolve_socket(fd), process.vmas.clone())
+    };
+
+    let Some(sid) = sid else {
+        regs.eax = u32::MAX;
+        return;
+    };
+
+    regs.eax = match socket_write(sid, buf, len, &vmas) {
+        Ok(n) => n as u32,
+        Err(e) => u32::MAX,
+    };
+}
+
+pub fn sys_socket_read(regs: &mut InterruptRegisters) {
+    let fd = regs.ebx as usize;
+    let buf = regs.ecx as usize;
+    let len = regs.edx as usize;
+
+    let (sid, vmas) = {
+        let mut scheduler = SCHEDULER.lock().expect("sys_socket_read | could not lock SCHEDULER");
+        let process = scheduler.current().expect("sys_socket_read | no process running");
+        (process.resolve_socket(fd), process.vmas.clone())
+    };
+
+    let Some(sid) = sid else {
+        regs.eax = u32::MAX;
+        return;
+    };
+
+    regs.eax = match socket_read(sid, buf, len, &vmas) {
+        Ok(n) => {
+            serial_println!("read that many bytes {}", n);
+            n as u32
+        }
+        Err(e) => u32::MAX,
+    };
+}
+
+pub fn sys_putnbr(regs: &mut InterruptRegisters) {
+    let scheduler = SCHEDULER.lock().expect("could not lock SCHEDULER");
+    serial_println!("Registers of pid: {}", scheduler.current.expect("no process running"));
+    serial_println!("eax: {:#010x}", regs.eax);
+    serial_println!("ebx: {:#010x}", regs.ebx);
+    serial_println!("ecx: {:#010x}", regs.ecx);
+    serial_println!("edx: {:#010x}", regs.edx);
+    serial_println!("esi: {:#010x}", regs.esi);
+    serial_println!("edi: {:#010x}", regs.edi);
+    serial_println!("ebp: {:#010x}", regs.ebp);
+    serial_println!("esp: {:#010x}", regs.esp);
+    regs.eax = 0;
+    serial_println!();
+}
+
 pub fn syscall(regs: &mut InterruptRegisters) {
+    let mut scheduler = SCHEDULER.lock().expect("sys_fork | could not lock SCHEDULER");
+    let cur = scheduler.current().expect("sys_fork | no process running");
+    serial_println!("syscall from pid {} with nbr {}", cur.pid, regs.eax);
+    drop(cur);
+    drop(scheduler);
     match regs.eax {
+        5 => sys_socket_create(regs),
+        6 => sys_socket_close(regs),
+        7 => sys_socket_read(regs),
+        8 => sys_socket_write(regs),
         35 => timer(regs),
+        42 => sys_putnbr(regs),
         57 => sys_fork(regs),
         60 => sys_exit(regs),
         _ => regs.eax = u32::MAX,

--- a/src/arch/x86/syscall.rs
+++ b/src/arch/x86/syscall.rs
@@ -13,10 +13,19 @@ use crate::{
 };
 
 pub extern "C" fn sys_exit(regs: &mut InterruptRegisters) {
-    let mut scheduler = SCHEDULER.lock().expect("timer | failed to lock SCHEDULER");
+    let mut scheduler = SCHEDULER.lock().expect("sys_exit | failed to lock SCHEDULER");
 
     let pid = scheduler.current().expect("sys_exit | no process running").pid;
     serial_println!("pid {} exited", pid);
+    let child = scheduler.table.get_mut(pid).expect("sys_exit | could not find exited process");
+
+    let mut sockets = SOCKETS.lock().expect("sys_exit | could not lock SOCKETS");
+
+    for socket_id in &child.socket_fds {
+        if let Some(socket_id) = socket_id {
+            sockets.close(*socket_id);
+        }
+    }
 
     scheduler.exit(pid);
 

--- a/src/arch/x86/syscall.rs
+++ b/src/arch/x86/syscall.rs
@@ -6,7 +6,7 @@ use crate::{
     arch::x86::{
         idt::InterruptRegisters,
         scheduler::{SCHEDULER, timer},
-        vmm::process::Process,
+        vmm::process::{Parent, Pid, Process},
     },
     serial_println,
     socket::{SOCKETS, Socket, SocketId, socket_close, socket_create, socket_read, socket_write},
@@ -17,14 +17,36 @@ pub extern "C" fn sys_exit(regs: &mut InterruptRegisters) {
 
     let pid = scheduler.current().expect("sys_exit | no process running").pid;
     serial_println!("pid {} exited", pid);
-    let child = scheduler.table.get_mut(pid).expect("sys_exit | could not find exited process");
 
-    let mut sockets = SOCKETS.lock().expect("sys_exit | could not lock SOCKETS");
-
-    for socket_id in &child.socket_fds {
-        if let Some(socket_id) = socket_id {
-            sockets.close(*socket_id);
+    {
+        let child = scheduler.table.get_mut(pid).expect("sys_exit | could not find exited process");
+        let mut sockets = SOCKETS.lock().expect("sys_exit | could not lock SOCKETS");
+        for socket_id in &child.socket_fds {
+            if let Some(socket_id) = socket_id {
+                sockets.close(*socket_id);
+            }
         }
+    }
+
+    // Resolve children to parent
+    {
+        let current = scheduler.table.get_mut(pid).expect("sys_exit | could not find exited process");
+        let children = current.children.clone();
+        let parent_id = match current.parent {
+            Parent::Root => panic!("root process exited"),
+            Parent::Pid(id) => id,
+        };
+        let _ = current;
+
+        for c in &children {
+            let child = scheduler.table.get_mut(*c).expect("sys_exit | could not find exited process");
+            child.parent = Parent::Pid(parent_id);
+            let parent = scheduler.table.get_mut(parent_id).expect("sys_exit | could not find exited process");
+            parent.children.push(*c);
+        }
+        let parent = scheduler.table.get_mut(parent_id).expect("sys_exit | parent not in table");
+        parent.children.retain(|&c| c != pid);
+        parent.children_stopped.push(pid);
     }
 
     scheduler.exit(pid);

--- a/src/arch/x86/syscall.rs
+++ b/src/arch/x86/syscall.rs
@@ -25,7 +25,6 @@ pub extern "C" fn sys_exit(regs: &mut InterruptRegisters) {
         }
     }
 
-    // Resolve children to parent
     {
         let current = scheduler.table.get_mut(pid).expect("sys_exit | could not find exited process");
         let children = current.children.clone();
@@ -61,7 +60,6 @@ pub fn sys_fork(regs: &mut InterruptRegisters) {
     parent.saved_registers = *regs;
     let mut child = Process::from_process(parent);
 
-    // add one to all references to sockets
     for socket_id in child.socket_fds.iter().flatten() {
         let mut sockets = SOCKETS.lock().expect("sys_fork | could not lock SOCKETS");
         let _ = sockets.add_ref(*socket_id);
@@ -69,7 +67,7 @@ pub fn sys_fork(regs: &mut InterruptRegisters) {
 
     child.saved_registers.eax = 0;
 
-    let _ = parent; // drop
+    let _ = parent;
     let child_pid = scheduler.spawn(child);
 
     let parent = scheduler.current().expect("sys_fork | no process running");
@@ -85,9 +83,6 @@ pub fn sys_getpid(regs: &mut InterruptRegisters) {
 }
 
 pub fn sys_socket_create(regs: &mut InterruptRegisters) {
-    // Create the underlying socket first, then install it in the current
-    // process's fd table. Two locks, never held at the same time.
-
     let sid = socket_create();
 
     let mut scheduler = SCHEDULER.lock().expect("sys_socket_create | could not lock SCHEDULER");
@@ -99,8 +94,6 @@ pub fn sys_socket_create(regs: &mut InterruptRegisters) {
 pub fn sys_socket_close(regs: &mut InterruptRegisters) {
     let fd = regs.ebx as usize;
 
-    // Remove the fd from the process, then drop the scheduler lock before
-    // touching the global socket table.
     let sid = {
         let mut scheduler = SCHEDULER.lock().expect("sys_socket_close | could not lock SCHEDULER");
         let process = scheduler.current().expect("sys_socket_close | no process running");
@@ -121,7 +114,6 @@ pub fn sys_socket_write(regs: &mut InterruptRegisters) {
     let buf = regs.ecx as usize;
     let len = regs.edx as usize;
 
-    // Snapshot fd → SocketId + VMAs, then release SCHEDULER before the copy.
     let (sid, vmas) = {
         let mut scheduler = SCHEDULER.lock().expect("sys_socket_write | could not lock SCHEDULER");
         let process = scheduler.current().expect("sys_socket_write | no process running");

--- a/src/arch/x86/syscall.rs
+++ b/src/arch/x86/syscall.rs
@@ -1,15 +1,14 @@
 #![allow(clippy::expect_used)]
 #![allow(clippy::missing_panics_doc)]
-use alloc::format;
 
 use crate::{
     arch::x86::{
         idt::InterruptRegisters,
         scheduler::{SCHEDULER, timer},
-        vmm::process::{Parent, Pid, Process},
+        vmm::process::{Parent, Process},
     },
     serial_println,
-    socket::{SOCKETS, Socket, SocketId, socket_close, socket_create, socket_read, socket_write},
+    socket::{SOCKETS, socket_close, socket_create, socket_read, socket_write},
 };
 
 pub extern "C" fn sys_exit(regs: &mut InterruptRegisters) {

--- a/src/arch/x86/syscall.rs
+++ b/src/arch/x86/syscall.rs
@@ -170,6 +170,15 @@ pub fn sys_socket_read(regs: &mut InterruptRegisters) {
     };
 }
 
+pub fn sys_am_super_user(regs: &mut InterruptRegisters) {
+    let mut scheduler = SCHEDULER.lock().expect("sys_fork | could not lock SCHEDULER");
+    let cur = scheduler.current().expect("sys_fork | no process running");
+    regs.eax = match cur.super_user {
+        true => 1,
+        false => 2,
+    }
+}
+
 pub fn sys_putnbr(regs: &mut InterruptRegisters) {
     let scheduler = SCHEDULER.lock().expect("could not lock SCHEDULER");
     serial_println!("Registers of pid: {}", scheduler.current.expect("no process running"));
@@ -200,6 +209,7 @@ pub fn syscall(regs: &mut InterruptRegisters) {
         42 => sys_putnbr(regs),
         57 => sys_fork(regs),
         60 => sys_exit(regs),
+        99 => sys_am_super_user(regs),
         _ => regs.eax = u32::MAX,
     }
 }

--- a/src/arch/x86/syscall.rs
+++ b/src/arch/x86/syscall.rs
@@ -9,7 +9,7 @@ use crate::{
         vmm::process::Process,
     },
     serial_println,
-    socket::{socket_close, socket_create, socket_read, socket_write},
+    socket::{SOCKETS, Socket, SocketId, socket_close, socket_create, socket_read, socket_write},
 };
 
 pub extern "C" fn sys_exit(regs: &mut InterruptRegisters) {
@@ -33,6 +33,15 @@ pub fn sys_fork(regs: &mut InterruptRegisters) {
     let parent = scheduler.current().expect("sys_fork | no process running");
     parent.saved_registers = *regs;
     let mut child = Process::from_process(parent);
+
+    // add one to all references to sockets
+    for socket_id in &child.socket_fds {
+        if let Some(socket_id) = socket_id {
+            let mut sockets = SOCKETS.lock().expect("sys_fork | could not lock SOCKETS");
+            sockets.add_ref(*socket_id);
+        }
+    }
+
     child.saved_registers.eax = 0;
 
     let _ = parent; // drop

--- a/src/arch/x86/syscall.rs
+++ b/src/arch/x86/syscall.rs
@@ -21,10 +21,8 @@ pub extern "C" fn sys_exit(regs: &mut InterruptRegisters) {
     {
         let child = scheduler.table.get_mut(pid).expect("sys_exit | could not find exited process");
         let mut sockets = SOCKETS.lock().expect("sys_exit | could not lock SOCKETS");
-        for socket_id in &child.socket_fds {
-            if let Some(socket_id) = socket_id {
-                sockets.close(*socket_id);
-            }
+        for socket_id in child.socket_fds.iter().flatten() {
+            let _ = sockets.close(*socket_id);
         }
     }
 
@@ -65,11 +63,9 @@ pub fn sys_fork(regs: &mut InterruptRegisters) {
     let mut child = Process::from_process(parent);
 
     // add one to all references to sockets
-    for socket_id in &child.socket_fds {
-        if let Some(socket_id) = socket_id {
-            let mut sockets = SOCKETS.lock().expect("sys_fork | could not lock SOCKETS");
-            sockets.add_ref(*socket_id);
-        }
+    for socket_id in child.socket_fds.iter().flatten() {
+        let mut sockets = SOCKETS.lock().expect("sys_fork | could not lock SOCKETS");
+        let _ = sockets.add_ref(*socket_id);
     }
 
     child.saved_registers.eax = 0;
@@ -116,7 +112,7 @@ pub fn sys_socket_close(regs: &mut InterruptRegisters) {
         None => u32::MAX,
         Some(sid) => match socket_close(sid) {
             Ok(()) => 0,
-            Err(e) => u32::MAX,
+            Err(_) => u32::MAX,
         },
     };
 }
@@ -140,7 +136,7 @@ pub fn sys_socket_write(regs: &mut InterruptRegisters) {
 
     regs.eax = match socket_write(sid, buf, len, &vmas) {
         Ok(n) => n as u32,
-        Err(e) => u32::MAX,
+        Err(_) => u32::MAX,
     };
 }
 
@@ -165,7 +161,7 @@ pub fn sys_socket_read(regs: &mut InterruptRegisters) {
             serial_println!("read that many bytes {}", n);
             n as u32
         }
-        Err(e) => u32::MAX,
+        Err(_) => u32::MAX,
     };
 }
 
@@ -207,7 +203,7 @@ pub fn syscall(regs: &mut InterruptRegisters) {
     let mut scheduler = SCHEDULER.lock().expect("sys_fork | could not lock SCHEDULER");
     let cur = scheduler.current().expect("sys_fork | no process running");
     serial_println!("syscall from pid {} with nbr {}", cur.pid, regs.eax);
-    drop(cur);
+    let _ = cur;
     drop(scheduler);
     match regs.eax {
         5 => sys_socket_create(regs),

--- a/src/arch/x86/syscall.rs
+++ b/src/arch/x86/syscall.rs
@@ -53,7 +53,6 @@ pub extern "C" fn sys_exit(regs: &mut InterruptRegisters) {
 
     let next = scheduler.schedule().expect("no process to run");
 
-    next.state = crate::arch::x86::vmm::process::ProcessState::Running;
     next.addressspace.load();
     *regs = next.saved_registers;
 }
@@ -194,6 +193,16 @@ pub fn sys_putnbr(regs: &mut InterruptRegisters) {
     serial_println!();
 }
 
+pub fn sys_wait(regs: &mut InterruptRegisters) {
+    {
+        let mut scheduler = SCHEDULER.lock().expect("sys_fork | could not lock SCHEDULER");
+        let cur = scheduler.current().expect("sys_fork | no process running");
+        cur.state = super::vmm::process::ProcessState::Waiting;
+    }
+
+    timer(regs);
+}
+
 pub fn syscall(regs: &mut InterruptRegisters) {
     let mut scheduler = SCHEDULER.lock().expect("sys_fork | could not lock SCHEDULER");
     let cur = scheduler.current().expect("sys_fork | no process running");
@@ -209,6 +218,7 @@ pub fn syscall(regs: &mut InterruptRegisters) {
         42 => sys_putnbr(regs),
         57 => sys_fork(regs),
         60 => sys_exit(regs),
+        98 => sys_wait(regs),
         99 => sys_am_super_user(regs),
         _ => regs.eax = u32::MAX,
     }

--- a/src/arch/x86/vmm/demand_pageing.rs
+++ b/src/arch/x86/vmm/demand_pageing.rs
@@ -1,4 +1,4 @@
-use core::ptr::copy_nonoverlapping;
+use core::ptr::{copy_nonoverlapping, write_bytes};
 
 use crate::{
     arch::x86::{
@@ -41,18 +41,27 @@ fn alloc_page(vaddr: usize, space: &mut Addressspace, vma: &VMA) -> Result<(), (
 
     let temp = 0xBFFF_F000 as *mut u8;
 
-    if let Some(offset) = vma.offset {
-        space.map(temp, paddr, Permissions::ReadWrite);
-        let diff = vaddr - vma.start;
+    space.map(temp, paddr, Permissions::ReadWrite);
 
-        // SAFETY:
-        // temp is a valid address because it just got mapped.
-        // offset + diff was validated when the binary was created.
-        unsafe {
-            copy_nonoverlapping((offset + diff) as *mut u8, temp, PAGE_SIZE);
+    let diff = vaddr - vma.start;
+    match vma.offset {
+        Some(offset) => {
+            // SAFETY:
+            // temp is a valid address because it just got mapped.
+            // offset + diff was validated when the binary was created.
+            unsafe {
+                copy_nonoverlapping((offset + diff) as *const u8, temp, PAGE_SIZE);
+            }
         }
-        space.unmap(temp);
+        None => {
+            // SAFETY:
+            // temp is valid because we just mapped it.
+            unsafe {
+                write_bytes(temp, 0, PAGE_SIZE);
+            }
+        }
     }
+    space.unmap(temp);
 
     space.map(vaddr as *mut u8, paddr, vma.permissions);
     Ok(())

--- a/src/arch/x86/vmm/process.rs
+++ b/src/arch/x86/vmm/process.rs
@@ -239,20 +239,6 @@ impl Scheduler {
         self.table.get_mut(pid)
     }
 
-    pub fn block(&mut self, pid: Pid) {
-        self.run_queue.remove(pid);
-        if let Some(proc) = self.table.get_mut(pid) {
-            proc.state = ProcessState::Blocked;
-        }
-    }
-
-    pub fn unblock(&mut self, pid: Pid) {
-        if let Some(proc) = self.table.get_mut(pid) {
-            proc.state = ProcessState::Ready;
-            self.run_queue.enqueue(pid);
-        }
-    }
-
     pub fn exit(&mut self, pid: Pid) {
         self.run_queue.remove(pid);
         self.table.remove(pid);

--- a/src/arch/x86/vmm/process.rs
+++ b/src/arch/x86/vmm/process.rs
@@ -1,9 +1,12 @@
 use alloc::{collections::VecDeque, vec::Vec};
 
-use crate::arch::x86::{
-    idt::InterruptRegisters,
-    scheduler::{Binary, Permissions},
-    vmm::addressspace::Addressspace,
+use crate::{
+    arch::x86::{
+        idt::InterruptRegisters,
+        scheduler::{Binary, Permissions},
+        vmm::addressspace::Addressspace,
+    },
+    socket::SocketId,
 };
 
 pub type Pid = usize;
@@ -40,6 +43,7 @@ pub struct Process {
     pub parent: Parent,
     pub children: Vec<Pid>,
     pub owner_id: OwnerId,
+    pub socket_fds: Vec<Option<SocketId>>,
 }
 
 impl Process {
@@ -63,6 +67,7 @@ impl Process {
             parent,
             children: Vec::new(),
             owner_id: 0,
+            socket_fds: Vec::new(),
         }
     }
     pub fn from_process(process: &mut Process) -> Self {
@@ -75,7 +80,29 @@ impl Process {
             parent: Parent::Pid(process.pid),
             children: Vec::new(),
             owner_id: 0,
+            socket_fds: process.socket_fds.clone(),
         }
+    }
+
+    /// Allocates a new fd pointing at `sid`, reusing freed slots first.
+    pub fn install_socket(&mut self, sid: SocketId) -> usize {
+        if let Some((idx, slot)) = self.socket_fds.iter_mut().enumerate().find(|(_, s)| s.is_none()) {
+            *slot = Some(sid);
+            idx
+        } else {
+            self.socket_fds.push(Some(sid));
+            self.socket_fds.len() - 1
+        }
+    }
+
+    /// Resolves an fd to its global SocketId.
+    pub fn resolve_socket(&self, fd: usize) -> Option<SocketId> {
+        self.socket_fds.get(fd).copied().flatten()
+    }
+
+    /// Frees the fd slot. Returns the SocketId that was there, if any.
+    pub fn remove_socket(&mut self, fd: usize) -> Option<SocketId> {
+        self.socket_fds.get_mut(fd)?.take()
     }
 }
 

--- a/src/arch/x86/vmm/process.rs
+++ b/src/arch/x86/vmm/process.rs
@@ -91,7 +91,6 @@ impl Process {
         }
     }
 
-    /// Allocates a new fd pointing at `sid`, reusing freed slots first.
     pub fn install_socket(&mut self, sid: SocketId) -> usize {
         if let Some((idx, slot)) = self.socket_fds.iter_mut().enumerate().find(|(_, s)| s.is_none()) {
             *slot = Some(sid);
@@ -103,12 +102,10 @@ impl Process {
     }
 
     #[allow(clippy::must_use_candidate)]
-    /// Resolves an fd to its global SocketId.
     pub fn resolve_socket(&self, fd: usize) -> Option<SocketId> {
         self.socket_fds.get(fd).copied().flatten()
     }
 
-    /// Frees the fd slot. Returns the SocketId that was there, if any.
     pub fn remove_socket(&mut self, fd: usize) -> Option<SocketId> {
         self.socket_fds.get_mut(fd)?.take()
     }

--- a/src/arch/x86/vmm/process.rs
+++ b/src/arch/x86/vmm/process.rs
@@ -46,11 +46,12 @@ pub struct Process {
     pub children_stopped: Vec<Pid>,
     pub owner_id: OwnerId,
     pub socket_fds: Vec<Option<SocketId>>,
+    pub super_user: bool,
 }
 
 impl Process {
     #[must_use]
-    pub fn new(binary: &Binary, parent: Parent) -> Self {
+    pub fn new(binary: &Binary, parent: Parent, super_user: bool) -> Self {
         Self {
             pid: 0,
             state: ProcessState::Ready,
@@ -71,6 +72,7 @@ impl Process {
             owner_id: 0,
             socket_fds: Vec::new(),
             children_stopped: Vec::new(),
+            super_user,
         }
     }
     pub fn from_process(process: &mut Process) -> Self {
@@ -85,6 +87,7 @@ impl Process {
             children_stopped: Vec::new(),
             owner_id: 0,
             socket_fds: process.socket_fds.clone(),
+            super_user: process.super_user,
         }
     }
 

--- a/src/arch/x86/vmm/process.rs
+++ b/src/arch/x86/vmm/process.rs
@@ -17,6 +17,7 @@ pub enum ProcessState {
     Running,
     Ready,
     Blocked,
+    Waiting,
     Zombie,
 }
 
@@ -42,6 +43,7 @@ pub struct Process {
     pub vmas: Vec<VMA>,
     pub parent: Parent,
     pub children: Vec<Pid>,
+    pub children_stopped: Vec<Pid>,
     pub owner_id: OwnerId,
     pub socket_fds: Vec<Option<SocketId>>,
 }
@@ -68,6 +70,7 @@ impl Process {
             children: Vec::new(),
             owner_id: 0,
             socket_fds: Vec::new(),
+            children_stopped: Vec::new(),
         }
     }
     pub fn from_process(process: &mut Process) -> Self {
@@ -79,6 +82,7 @@ impl Process {
             vmas: process.vmas.clone(),
             parent: Parent::Pid(process.pid),
             children: Vec::new(),
+            children_stopped: Vec::new(),
             owner_id: 0,
             socket_fds: process.socket_fds.clone(),
         }

--- a/src/arch/x86/vmm/process.rs
+++ b/src/arch/x86/vmm/process.rs
@@ -102,6 +102,7 @@ impl Process {
         }
     }
 
+    #[allow(clippy::must_use_candidate)]
     /// Resolves an fd to its global SocketId.
     pub fn resolve_socket(&self, fd: usize) -> Option<SocketId> {
         self.socket_fds.get(fd).copied().flatten()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod ps2;
 pub mod qemu;
 pub mod serial;
 pub mod shell;
+pub mod socket;
 pub mod stack_print_serial;
 pub mod terminal;
 pub mod tester;

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -14,9 +14,13 @@ fn panic(info: &PanicInfo) -> ! {
 
     cli!();
 
-    printkln!("KERNEL PANIC: {:?}\n", info.message());
-
-    serial_println!("KERNEL PANIC: {:?}", info.message());
+    if let Some(loc) = info.location() {
+        printkln!("KERNEL PANIC at {}:{}: {:?}\n", loc.file(), loc.line(), info.message());
+        serial_println!("KERNEL PANIC at {}:{}: {:?}", loc.file(), loc.line(), info.message());
+    } else {
+        printkln!("KERNEL PANIC: {:?}\n", info.message());
+        serial_println!("KERNEL PANIC: {:?}", info.message());
+    }
 
     unsafe {
         clear_regs!();

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,4 +1,7 @@
 // src/arch/x86/ipc/socket.rs
+#![allow(clippy::expect_used)]
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::missing_errors_doc)]
 use alloc::vec::Vec;
 
 use crate::arch::x86::{kernel_mutex::KernelMutex, scheduler::Permissions, vmm::process::VMA};
@@ -69,6 +72,7 @@ pub struct SocketTable {
 }
 
 impl SocketTable {
+    #[must_use]
     pub const fn new() -> Self {
         Self {
             sockets: Vec::new(),
@@ -88,7 +92,7 @@ impl SocketTable {
     }
 
     pub fn close(&mut self, id: SocketId) -> Result<(), SocketError> {
-        let mut slot = self.sockets.get_mut(id).ok_or(SocketError::BadSocket)?;
+        let slot = self.sockets.get_mut(id).ok_or(SocketError::BadSocket)?;
         match slot {
             None => Err(SocketError::BadSocket),
             Some(sock) => {
@@ -110,6 +114,12 @@ impl SocketTable {
 
     pub fn get_mut(&mut self, id: SocketId) -> Result<&mut Socket, SocketError> {
         self.sockets.get_mut(id).and_then(|s| s.as_mut()).ok_or(SocketError::BadSocket)
+    }
+}
+
+impl Default for SocketTable {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,0 +1,187 @@
+// src/arch/x86/ipc/socket.rs
+use alloc::vec::Vec;
+
+use crate::arch::x86::{kernel_mutex::KernelMutex, scheduler::Permissions, vmm::process::VMA};
+
+pub type SocketId = usize;
+
+/// Errors returned by socket operations. The syscall layer maps these to
+/// negative integers (errno-style) before handing them back to userspace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SocketError {
+    /// User pointer is null, misaligned, or its range escapes the user's VMAs.
+    BadAddress,
+    /// Referenced socket id does not exist.
+    BadSocket,
+}
+
+pub struct Socket {
+    pub references: usize,
+    buffer: Vec<u8>,
+}
+
+impl Default for Socket {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Socket {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            buffer: Vec::new(),
+            references: 1,
+        }
+    }
+
+    pub fn write(&mut self, data: &[u8]) -> usize {
+        self.buffer.extend_from_slice(data);
+        data.len()
+    }
+
+    pub fn read(&mut self, buf: &mut [u8]) -> usize {
+        let n = core::cmp::min(buf.len(), self.buffer.len());
+        for (i, b) in self.buffer.drain(..n).enumerate() {
+            buf[i] = b;
+        }
+        n
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+}
+
+/// Global table of sockets, keyed by [`SocketId`].
+///
+/// Uses the same `Vec<Option<_>>` + free-list pattern as [`ProcessTable`],
+/// so freed slots get reused before the table grows.
+pub struct SocketTable {
+    sockets: Vec<Option<Socket>>,
+    free_slots: Vec<SocketId>,
+}
+
+impl SocketTable {
+    pub const fn new() -> Self {
+        Self {
+            sockets: Vec::new(),
+            free_slots: Vec::new(),
+        }
+    }
+
+    pub fn create(&mut self) -> SocketId {
+        if let Some(id) = self.free_slots.pop() {
+            self.sockets[id] = Some(Socket::new());
+            id
+        } else {
+            let id = self.sockets.len();
+            self.sockets.push(Some(Socket::new()));
+            id
+        }
+    }
+
+    pub fn close(&mut self, id: SocketId) -> Result<(), SocketError> {
+        let mut slot = self.sockets.get_mut(id).ok_or(SocketError::BadSocket)?;
+        match slot {
+            None => Err(SocketError::BadSocket),
+            Some(sock) => {
+                sock.references -= 1;
+                if sock.references == 0 {
+                    slot.take();
+                    self.free_slots.push(id);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    pub fn add_ref(&mut self, id: SocketId) -> Result<(), SocketError> {
+        let socket = self.sockets.get_mut(id).and_then(|s| s.as_mut()).ok_or(SocketError::BadSocket)?;
+        socket.references += 1;
+        Ok(())
+    }
+
+    pub fn get_mut(&mut self, id: SocketId) -> Result<&mut Socket, SocketError> {
+        self.sockets.get_mut(id).and_then(|s| s.as_mut()).ok_or(SocketError::BadSocket)
+    }
+}
+
+pub static SOCKETS: KernelMutex<SocketTable> = KernelMutex::new(SocketTable::new());
+
+/// Verifies that `[addr, addr + len)` is fully covered by a single VMA and
+/// that the VMA has the required permissions. Mirrors the check used in
+/// `page_fault`.
+fn validate_user_range(vmas: &[VMA], addr: usize, len: usize, need_write: bool) -> bool {
+    if len == 0 {
+        return true;
+    }
+    let Some(end_inclusive) = addr.checked_add(len - 1) else {
+        return false;
+    };
+
+    for vma in vmas {
+        let Some(vma_end_inclusive) = vma.start.checked_add(vma.size).map(|e| e - 1) else {
+            continue;
+        };
+        if vma.start > addr || end_inclusive > vma_end_inclusive {
+            continue;
+        }
+        if need_write && !matches!(vma.permissions, Permissions::ReadWrite) {
+            return false;
+        }
+        return true;
+    }
+    false
+}
+
+/// Writes `len` bytes from the user pointer `buf` into the socket identified
+/// by `id`. Returns the number of bytes written on success.
+///
+/// This is the layer that owns the unsafe pointer dereference: the syscall
+/// shim only forwards register values into here.
+pub fn socket_write(id: SocketId, buf: usize, len: usize, vmas: &[VMA]) -> Result<usize, SocketError> {
+    if !validate_user_range(vmas, buf, len, false) {
+        return Err(SocketError::BadAddress);
+    }
+    // SAFETY:
+    // The range was just validated as fully inside one of the current
+    // process's VMAs, the current address space is loaded, and the slice is
+    // only used for the duration of this call.
+    let data = unsafe { core::slice::from_raw_parts(buf as *const u8, len) };
+
+    let mut table = SOCKETS.lock().expect("socket_write | could not lock SOCKETS");
+    let socket = table.get_mut(id)?;
+    Ok(socket.write(data))
+}
+
+/// Reads up to `len` bytes from the socket `id` into the user pointer `buf`.
+/// Returns the number of bytes actually read.
+pub fn socket_read(id: SocketId, buf: usize, len: usize, vmas: &[VMA]) -> Result<usize, SocketError> {
+    if !validate_user_range(vmas, buf, len, true) {
+        return Err(SocketError::BadAddress);
+    }
+    // SAFETY:
+    // Range was validated as ReadWrite and is in the current address space.
+    let out = unsafe { core::slice::from_raw_parts_mut(buf as *mut u8, len) };
+
+    let mut table = SOCKETS.lock().expect("socket_read | could not lock SOCKETS");
+    let socket = table.get_mut(id)?;
+    Ok(socket.read(out))
+}
+
+pub fn socket_create() -> SocketId {
+    let mut table = SOCKETS.lock().expect("socket_create | could not lock SOCKETS");
+    table.create()
+}
+
+pub fn socket_close(id: SocketId) -> Result<(), SocketError> {
+    let mut table = SOCKETS.lock().expect("socket_close | could not lock SOCKETS");
+    table.close(id)
+}

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,4 +1,3 @@
-// src/arch/x86/ipc/socket.rs
 #![allow(clippy::expect_used)]
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::missing_errors_doc)]
@@ -8,13 +7,9 @@ use crate::arch::x86::{kernel_mutex::KernelMutex, scheduler::Permissions, vmm::p
 
 pub type SocketId = usize;
 
-/// Errors returned by socket operations. The syscall layer maps these to
-/// negative integers (errno-style) before handing them back to userspace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SocketError {
-    /// User pointer is null, misaligned, or its range escapes the user's VMAs.
     BadAddress,
-    /// Referenced socket id does not exist.
     BadSocket,
 }
 
@@ -62,10 +57,6 @@ impl Socket {
     }
 }
 
-/// Global table of sockets, keyed by [`SocketId`].
-///
-/// Uses the same `Vec<Option<_>>` + free-list pattern as [`ProcessTable`],
-/// so freed slots get reused before the table grows.
 pub struct SocketTable {
     sockets: Vec<Option<Socket>>,
     free_slots: Vec<SocketId>,
@@ -125,9 +116,6 @@ impl Default for SocketTable {
 
 pub static SOCKETS: KernelMutex<SocketTable> = KernelMutex::new(SocketTable::new());
 
-/// Verifies that `[addr, addr + len)` is fully covered by a single VMA and
-/// that the VMA has the required permissions. Mirrors the check used in
-/// `page_fault`.
 fn validate_user_range(vmas: &[VMA], addr: usize, len: usize, need_write: bool) -> bool {
     if len == 0 {
         return true;
@@ -151,11 +139,6 @@ fn validate_user_range(vmas: &[VMA], addr: usize, len: usize, need_write: bool) 
     false
 }
 
-/// Writes `len` bytes from the user pointer `buf` into the socket identified
-/// by `id`. Returns the number of bytes written on success.
-///
-/// This is the layer that owns the unsafe pointer dereference: the syscall
-/// shim only forwards register values into here.
 pub fn socket_write(id: SocketId, buf: usize, len: usize, vmas: &[VMA]) -> Result<usize, SocketError> {
     if !validate_user_range(vmas, buf, len, false) {
         return Err(SocketError::BadAddress);
@@ -171,8 +154,6 @@ pub fn socket_write(id: SocketId, buf: usize, len: usize, vmas: &[VMA]) -> Resul
     Ok(socket.write(data))
 }
 
-/// Reads up to `len` bytes from the socket `id` into the user pointer `buf`.
-/// Returns the number of bytes actually read.
 pub fn socket_read(id: SocketId, buf: usize, len: usize, vmas: &[VMA]) -> Result<usize, SocketError> {
     if !validate_user_range(vmas, buf, len, true) {
         return Err(SocketError::BadAddress);


### PR DESCRIPTION
Added 0'ing the demand pages.
Added panic messages that include line and file for better debugging.
Added wait - for waiting on exiting child processes. 
Added socket create/close/read/write
Added putnbr syscall
Added sys_superuser -> to demonstrate support for permissions on processes.

<details>
  <summary>Rust API Guidelines Checklist</summary>
  
- **Naming** _(crate aligns with Rust naming conventions)_
    - [ ] Casing conforms to RFC 430 ([C-CASE](https://rust-lang.github.io/api-guidelines/naming.html#c-case))
    - [ ] Ad-hoc conversions follow `as_`, `to_`, `into_` conventions ([C-CONV](https://rust-lang.github.io/api-guidelines/naming.html#c-conv))
    - [ ] Getter names follow Rust convention ([C-GETTER](https://rust-lang.github.io/api-guidelines/naming.html#c-getter))
    - [ ] Methods on collections that produce iterators follow `iter`, `iter_mut`, `into_iter` ([C-ITER](https://rust-lang.github.io/api-guidelines/naming.html#c-iter))
    - [ ] Iterator type names match the methods that produce them ([C-ITER-TY](https://rust-lang.github.io/api-guidelines/naming.html#c-iter-ty))
    - [ ] Feature names are free of placeholder words ([C-FEATURE](https://rust-lang.github.io/api-guidelines/naming.html#c-feature))
    - [ ] Names use a consistent word order ([C-WORD-ORDER](https://rust-lang.github.io/api-guidelines/naming.html#c-word-order))
- **Interoperability** _(crate interacts nicely with other library functionality)_
    - [ ] Types eagerly implement common traits ([C-COMMON-TRAITS](https://rust-lang.github.io/api-guidelines/interoperability.html#c-common-traits))
        - `Copy`, `Clone`, `Eq`, `PartialEq`, `Ord`, `PartialOrd`, `Hash`, `Debug`,
          `Display`, `Default`
    - [ ] Conversions use the standard traits `From`, `AsRef`, `AsMut` ([C-CONV-TRAITS](https://rust-lang.github.io/api-guidelines/interoperability.html#c-conv-traits))
    - [ ] Collections implement `FromIterator` and `Extend` ([C-COLLECT](https://rust-lang.github.io/api-guidelines/interoperability.html#c-collect))
    - [ ] Data structures implement Serde's `Serialize`, `Deserialize` ([C-SERDE](https://rust-lang.github.io/api-guidelines/interoperability.html#c-serde))
    - [ ] Types are `Send` and `Sync` where possible ([C-SEND-SYNC](https://rust-lang.github.io/api-guidelines/interoperability.html#c-send-sync))
    - [ ] Error types are meaningful and well-behaved ([C-GOOD-ERR](https://rust-lang.github.io/api-guidelines/interoperability.html#c-good-err))
    - [ ] Binary number types provide `Hex`, `Octal`, `Binary` formatting ([C-NUM-FMT](https://rust-lang.github.io/api-guidelines/interoperability.html#c-num-fmt))
    - [ ] Generic reader/writer functions take `R: Read` and `W: Write` by value ([C-RW-VALUE](https://rust-lang.github.io/api-guidelines/interoperability.html#c-rw-value))
- **Macros** _(crate presents well-behaved macros)_
    - [ ] Input syntax is evocative of the output ([C-EVOCATIVE](https://rust-lang.github.io/api-guidelines/macros.html#c-evocative))
    - [ ] Macros compose well with attributes ([C-MACRO-ATTR](https://rust-lang.github.io/api-guidelines/macros.html#c-macro-attr))
    - [ ] Item macros work anywhere that items are allowed ([C-ANYWHERE](https://rust-lang.github.io/api-guidelines/macros.html#c-anywhere))
    - [ ] Item macros support visibility specifiers ([C-MACRO-VIS](https://rust-lang.github.io/api-guidelines/macros.html#c-macro-vis))
    - [ ] Type fragments are flexible ([C-MACRO-TY](https://rust-lang.github.io/api-guidelines/macros.html#c-macro-ty))
- **Documentation** _(crate is abundantly documented)_
    - [ ] Crate level docs are thorough and include examples ([C-CRATE-DOC](https://rust-lang.github.io/api-guidelines/documentation.html#c-crate-doc))
    - [ ] All items have a rustdoc example ([C-EXAMPLE](https://rust-lang.github.io/api-guidelines/documentation.html#c-example))
    - [ ] Examples use `?`, not `try!`, not `unwrap` ([C-QUESTION-MARK](https://rust-lang.github.io/api-guidelines/documentation.html#c-question-mark))
    - [ ] Function docs include error, panic, and safety considerations ([C-FAILURE](https://rust-lang.github.io/api-guidelines/documentation.html#c-failure))
    - [ ] Prose contains hyperlinks to relevant things ([C-LINK](https://rust-lang.github.io/api-guidelines/documentation.html#c-link))
    - [ ] Cargo.toml includes all common metadata ([C-METADATA](https://rust-lang.github.io/api-guidelines/documentation.html#c-metadata))
        - authors, description, license, homepage, documentation, repository,
          keywords, categories
    - [ ] Release notes document all significant changes ([C-RELNOTES](https://rust-lang.github.io/api-guidelines/documentation.html#c-relnotes))
    - [ ] Rustdoc does not show unhelpful implementation details ([C-HIDDEN](https://rust-lang.github.io/api-guidelines/documentation.html#c-hidden))
- **Predictability** _(crate enables legible code that acts how it looks)_
    - [ ] Smart pointers do not add inherent methods ([C-SMART-PTR](https://rust-lang.github.io/api-guidelines/documentation.html#c-smart-ptr))
    - [ ] Conversions live on the most specific type involved ([C-CONV-SPECIFIC](https://rust-lang.github.io/api-guidelines/documentation.html#c-cow-specific))
    - [ ] Functions with a clear receiver are methods ([C-METHOD](https://rust-lang.github.io/api-guidelines/documentation.html#c-method))
    - [ ] Functions do not take out-parameters ([C-NO-OUT](https://rust-lang.github.io/api-guidelines/documentation.html#c-no-out))
    - [ ] Operator overloads are unsurprising ([C-OVERLOAD](https://rust-lang.github.io/api-guidelines/documentation.html#c-overload))
    - [ ] Only smart pointers implement `Deref` and `DerefMut` ([C-DEREF](https://rust-lang.github.io/api-guidelines/documentation.html#c-deref))
    - [ ] Constructors are static, inherent methods ([C-CTOR](https://rust-lang.github.io/api-guidelines/documentation.html#c-ctor))
- **Flexibility** _(crate supports diverse real-world use cases)_
    - [ ] Functions expose intermediate results to avoid duplicate work ([C-INTERMEDIATE](https://rust-lang.github.io/api-guidelines/documentation.html#c-intermediate))
    - [ ] Caller decides where to copy and place data ([C-CALLER-CONTROL](https://rust-lang.github.io/api-guidelines/documentation.html#c-caller-control))
    - [ ] Functions minimize assumptions about parameters by using generics ([C-GENERIC](https://rust-lang.github.io/api-guidelines/documentation.html#c-generic))
    - [ ] Traits are object-safe if they may be useful as a trait object ([C-OBJECT](https://rust-lang.github.io/api-guidelines/documentation.html#c-object))
- **Type safety** _(crate leverages the type system effectively)_
    - [ ] Newtypes provide static distinctions ([C-NEWTYPE](https://rust-lang.github.io/api-guidelines/documentation.html#c-newtype))
    - [ ] Arguments convey meaning through types, not `bool` or `Option` ([C-CUSTOM-TYPE](https://rust-lang.github.io/api-guidelines/documentation.html#c-custom-type))
    - [ ] Types for a set of flags are `bitflags`, not enums ([C-BITFLAG](https://rust-lang.github.io/api-guidelines/documentation.html#c-bitflags))
    - [ ] Builders enable construction of complex values ([C-BUILDER](https://rust-lang.github.io/api-guidelines/documentation.html#c-builder))
- **Dependability** _(crate is unlikely to do the wrong thing)_
    - [ ] Functions validate their arguments ([C-VALIDATE](https://rust-lang.github.io/api-guidelines/documentation.html#c-validate))
    - [ ] Destructors never fail ([C-DTOR-FAIL](https://rust-lang.github.io/api-guidelines/documentation.html#c-dtor-fail))
    - [ ] Destructors that may block have alternatives ([C-DTOR-BLOCK](https://rust-lang.github.io/api-guidelines/documentation.html#c-dtor-block))
- **Debuggability** _(crate is conducive to easy debugging)_
    - [ ] All public types implement `Debug` ([C-DEBUG](https://rust-lang.github.io/api-guidelines/documentation.html#c-debug))
    - [ ] `Debug` representation is never empty ([C-DEBUG-NONEMPTY](https://rust-lang.github.io/api-guidelines/documentation.html#c-debug-nonempty))
- **Future proofing** _(crate is free to improve without breaking users' code)_
    - [ ] Sealed traits protect against downstream implementations ([C-SEALED](https://rust-lang.github.io/api-guidelines/documentation.html#c-sealed))
    - [ ] Structs have private fields ([C-STRUCT-PRIVATE](https://rust-lang.github.io/api-guidelines/documentation.html#c-struct-private))
    - [ ] Newtypes encapsulate implementation details ([C-NEWTYPE-HIDE](https://rust-lang.github.io/api-guidelines/documentation.html#c-newtype-hide))
    - [ ] Data structures do not duplicate derived trait bounds ([C-STRUCT-BOUNDS](https://rust-lang.github.io/api-guidelines/documentation.html#c-struct-bounds))
- **Necessities** _(to whom they matter, they really matter)_
    - [ ] Public dependencies of a stable crate are stable ([C-STABLE](https://rust-lang.github.io/api-guidelines/documentation.html#c-stable))
    - [ ] Crate and its dependencies have a permissive license ([C-PERMISSIVE](https://rust-lang.github.io/api-guidelines/documentation.html#c-permissive))

</details>

